### PR TITLE
Fix cursor-helper rename --copy metadata synchronization and cache/state consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .claude/settings.local.json
 *.tar.gz
 .vscode/
+.cursor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--force-index` option for `rename --copy` to force composer index rebuild (`cursor-helper rename --copy --force-index`).
+
+### Fixed
+
+- Fix `rename --copy` to preserve full chat history visibility by synchronizing `composer.composerData` and normalizing workspace references in the copied `workspaceStorage` DB.
+- Extend `rename` copy flow to copy the full `workspaceStorage/<hash>/` directory, update both `storage.json` and `globalStorage/state.vscdb`, and clear stale Electron cache directories to prevent UI desync.
+
 ## [0.2.1] - 2026-01-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,9 +48,36 @@ cursor-helper rename /path/to/old-project /path/to/new-project
 # Copy instead of move
 cursor-helper rename --copy /path/to/project /path/to/project-copy
 
+# Copy with full composer index rebuild (force re-index of chat sidebar)
+cursor-helper rename --copy --force-index /path/to/project /path/to/project-copy
+
 # Preview changes first
 cursor-helper rename -n /path/to/old /path/to/new
 ```
+
+For `--copy`, the command now:
+
+- copies the full `workspaceStorage/<hash>/` directory instead of only `state.vscdb`
+- updates `folderUri` / workspace mappings in `storage.json` and `globalStorage/state.vscdb`
+- rewrites `composer.composerData` in the target workspace database (including normalized paths and hashes)
+- clears stale cache folders:
+  - `<Cursor config>/CachedData/`
+  - `<Cursor config>/GPUCache/`
+  - `<new workspace hash>/anysphere.cursor-retrieval/`
+
+Suggested validation cases:
+
+1. **same filesystem rename**
+   `cursor-helper rename /tmp/proj /tmp/proj-renamed` and verify chat count matches before/after in `list`.
+
+2. **cross-filesystem copy**
+   Copy a project from one mount to another and run `cursor-helper rename --copy /mnt/source/proj /mnt/other/proj-copy`; confirm `list` shows full history in Cursor.
+
+3. **UI refresh path**
+   Open Cursor after copy and confirm:
+   - sidebar shows full chat list
+   - individual sessions load correctly
+   - no duplicate or missing workspace prompts
 
 ### `export-chat` — Export Everything Cursor Hides
 

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -84,25 +84,25 @@ pub fn execute(
     let action = if copy_mode { "Copying" } else { "Moving" };
 
     // Print summary
-    println!("{}");
+    println!();
     println!(
         "{}",
         format!("=== Cursor Project {} Tool ===", mode).green()
     );
-    println!("{}");
+    println!();
     println!("Old path: {}", old_path.display());
     println!("New path: {}", new_path.display());
     println!("Mode: {}", mode);
     println!("Force index: {}", if force_index { "on" } else { "off" });
-    println!("{}", "");
+    println!();
     println!("Old folder ID: {}", old_folder_id);
     println!("Old workspace hash: {}", old_workspace_hash);
-    println!("{}", "");
+    println!();
 
     // Check if old data exists
     print_exists_status("Cursor projects dir", &old_projects_dir);
     print_exists_status("Workspace storage dir", &old_workspace_dir);
-    println!("{}");
+    println!();
 
     // Confirm (skip in dry-run)
     if !dry_run {
@@ -358,7 +358,7 @@ pub fn execute(
     // Step 8: Clear stale cache directories
     println!("{}", "Step 8: Clearing stale cache data...".green());
     if !dry_run {
-        if let Ok(true) = new_workspace_dir.exists().then_some(true) {
+        if new_workspace_dir.exists() {
             clear_path(
                 &new_workspace_dir.join("anysphere.cursor-retrieval"),
                 dry_run,
@@ -377,9 +377,9 @@ pub fn execute(
     }
 
     // Done!
-    println!("{}");
+    println!();
     println!("{}", format!("=== {} complete! ===", mode).green());
-    println!("{}");
+    println!();
 
     if dry_run {
         println!("This was a dry-run. No changes were made.");
@@ -388,7 +388,7 @@ pub fn execute(
         println!("You can now open {} in Cursor.", new_path.display());
         println!("Your chat history and workspace settings should be preserved.");
         if copy_mode {
-            println!("{}");
+            println!();
             println!(
                 "Original project at {} was kept intact.",
                 old_path.display()
@@ -400,6 +400,7 @@ pub fn execute(
 }
 
 /// Update composer index in workspace state DB when copied from an existing workspace
+#[allow(clippy::too_many_arguments)]
 fn sync_workspace_composer_index(
     source_db_path: Option<&Path>,
     target_db_path: &Path,
@@ -437,9 +438,7 @@ fn sync_workspace_composer_index(
 
     let target_data = fetch_composer_data(&target_conn)?;
 
-    let target_has_all_composers = target_data
-        .as_deref()
-        .is_some_and(|data| has_all_composers(data));
+    let target_has_all_composers = target_data.as_deref().is_some_and(has_all_composers);
     let mut needs_update = force_index || !target_has_all_composers;
     if source_data.is_none() && force_index {
         needs_update = true;

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -442,16 +442,15 @@ fn sync_workspace_composer_index(
         new_workspace_hash,
     );
 
-    let needs_update = force_index
-        || data_to_write.contains(old_uri)
+    let needs_update = data_to_write.contains(old_uri)
         || data_to_write.contains(old_path)
         || data_to_write.contains(old_workspace_hash);
 
-    if !needs_update {
+    if !needs_update && !force_index {
         return Ok(false);
     }
 
-    if normalized == data_to_write {
+    if normalized == data_to_write && !force_index {
         return Ok(false);
     }
 
@@ -538,7 +537,7 @@ fn normalize_text_replacements(data: &str, replacements: &[(&str, &str)]) -> Str
             token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{seed}__");
         }
 
-        working = working.replace(*old, &token);
+        working = replace_composer_scoped_matches(&working, old, &token);
         placeholder_map.push((token, *old));
         seed += 1;
     }
@@ -554,6 +553,47 @@ fn normalize_text_replacements(data: &str, replacements: &[(&str, &str)]) -> Str
     }
 
     normalized
+}
+
+fn replace_composer_scoped_matches(value: &str, pattern: &str, replacement: &str) -> String {
+    if pattern.is_empty() {
+        return value.to_string();
+    }
+
+    let mut offset = 0usize;
+    let mut normalized = String::with_capacity(value.len());
+
+    while let Some(pos) = value[offset..].find(pattern) {
+        let absolute_pos = offset + pos;
+
+        normalized.push_str(&value[offset..absolute_pos]);
+
+        let next_offset = absolute_pos + pattern.len();
+        let suffix = value[next_offset..].chars().next();
+        if is_composer_value_suffix_terminator(suffix) {
+            normalized.push_str(replacement);
+        } else {
+            normalized.push_str(pattern);
+        }
+
+        offset = next_offset;
+    }
+
+    normalized.push_str(&value[offset..]);
+    normalized
+}
+
+fn is_composer_value_suffix_terminator(suffix: Option<char>) -> bool {
+    match suffix {
+        None => true,
+        Some(suffix) => {
+            !suffix.is_ascii_alphanumeric()
+                && suffix != '_'
+                && suffix != '-'
+                && suffix != '.'
+                && suffix != '%'
+        }
+    }
 }
 
 /// Create backup snapshots before mutating Cursor metadata.
@@ -1009,6 +1049,52 @@ mod tests {
     }
 
     #[test]
+    fn test_sync_workspace_composer_index_force_index_writes_without_stale_references() {
+        let temp_dir = TempDir::new().unwrap();
+        let target_db = temp_dir.path().join("target.vscdb");
+
+        let composer_payload = r#"{"allComposers":[{"id":"file:///new/project/hash_new"}]}"#;
+        let conn = Connection::open(&target_db).unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            ("composer.composerData", composer_payload),
+        )
+        .unwrap();
+        drop(conn);
+
+        let updated = sync_workspace_composer_index(
+            None,
+            &target_db,
+            "file:///old/project",
+            "file:///new/project",
+            "/old/project",
+            "/new/project",
+            "hash_old",
+            "hash_new",
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert!(updated);
+
+        let conn = Connection::open(&target_db).unwrap();
+        let value: String = conn
+            .query_row(
+                "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, composer_payload);
+    }
+
+    #[test]
     fn test_normalize_composer_data_avoids_uri_double_expand() {
         let value = r#"{"allComposers":[{"id":"file:///home/user/project/hash_old","path":"/home/user/project","title":"project"}]}"#;
 
@@ -1027,6 +1113,26 @@ mod tests {
             r#"{"allComposers":[{"id":"file:///home/user/project-copy/hash_new","path":"/home/user/project-copy","title":"project"}]}"#
         );
         assert!(!normalized.contains("file:///home/user/project-copy-copy"));
+    }
+
+    #[test]
+    fn test_normalize_composer_data_preserves_prefix_sibling_paths_in_same_cell() {
+        let value = r#"{"active":"file:///home/user/project","other":"file:///home/user/projects/foo","cache":"hash_old"}"#;
+
+        let normalized = normalize_composer_data(
+            value,
+            "file:///home/user/project",
+            "file:///home/user/project-copy",
+            "/home/user/project",
+            "/home/user/project-copy",
+            "hash_old",
+            "hash_new",
+        );
+
+        assert_eq!(
+            normalized,
+            r#"{"active":"file:///home/user/project-copy","other":"file:///home/user/projects/foo","cache":"hash_new"}"#
+        );
     }
 
     #[test]

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -10,7 +10,6 @@ use anyhow::{bail, Context, Result};
 use fs_extra::dir::{self, CopyOptions};
 use owo_colors::OwoColorize;
 use rusqlite::Connection;
-use serde_json::Value;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -138,25 +137,15 @@ pub fn execute(
     let new_uri = path_to_file_uri(&new_path)?;
     let old_path_raw = old_path.to_string_lossy().to_string();
     let new_path_raw = new_path.to_string_lossy().to_string();
-
-    // Compute new identifiers
-    let new_folder_id = folder_id::path_to_folder_id(&new_path);
-    let new_workspace_hash = if dry_run {
-        if copy_mode {
-            println!(
-                "  {}",
-                "(New folder would get new birthtime, hash computed at runtime)".yellow()
-            );
-            "<computed-at-runtime>".to_string()
-        } else {
-            estimate_hash_after_move(&old_path, &new_path)?
-        }
+    let estimated_move_hash = if !copy_mode {
+        Some(estimate_hash_after_move(&old_path, &new_path)?)
     } else {
-        workspace::compute_workspace_hash(&new_path)?
+        None
     };
 
+    // Compute new folder ID (before creating destination)
+    let new_folder_id = folder_id::path_to_folder_id(&new_path);
     println!("New folder ID: {}", new_folder_id);
-    println!("New workspace hash: {}", new_workspace_hash);
 
     // Step 1: Copy/Move the project folder
     println!(
@@ -165,6 +154,25 @@ pub fn execute(
     );
     println!("  {} -> {}", old_path.display(), new_path.display());
     copy_or_move(&old_path, &new_path, copy_mode, dry_run)?;
+
+    // Compute new workspace hash after destination exists
+    let new_workspace_hash = if dry_run {
+        if copy_mode {
+            println!(
+                "  {}",
+                "(New folder would get new birthtime, hash computed at runtime)".yellow()
+            );
+            "<computed-at-runtime>".to_string()
+        } else {
+            estimated_move_hash
+                .clone()
+                .context("Failed to estimate moved workspace hash")?
+        }
+    } else {
+        workspace::compute_workspace_hash(&new_path)?
+    };
+
+    println!("New workspace hash: {}", new_workspace_hash);
 
     let mut source_composer_db: Option<PathBuf> = None;
     if copy_mode && !dry_run && old_workspace_dir.exists() {
@@ -325,28 +333,18 @@ pub fn execute(
             );
         }
 
-        let uri_modified = storage::update_global_state_db(
+        let global_modified = storage::update_global_state_db(
             &global_state_db_path,
+            &old_path_raw,
+            &new_path_raw,
             &old_uri,
             &new_uri,
             &old_workspace_hash,
             &new_workspace_hash,
             dry_run,
         )?;
-        let path_modified = if old_path_raw != new_path_raw {
-            storage::update_global_state_db(
-                &global_state_db_path,
-                &old_path_raw,
-                &new_path_raw,
-                &old_workspace_hash,
-                &new_workspace_hash,
-                dry_run,
-            )?
-        } else {
-            false
-        };
 
-        if uri_modified || path_modified {
+        if global_modified {
             println!("  -> Updated global state references");
         } else {
             println!("  -> No matching global state references found");
@@ -438,17 +436,7 @@ fn sync_workspace_composer_index(
 
     let target_data = fetch_composer_data(&target_conn)?;
 
-    let target_has_all_composers = target_data.as_deref().is_some_and(has_all_composers);
-    let mut needs_update = force_index || !target_has_all_composers;
-    if source_data.is_none() && force_index {
-        needs_update = true;
-    }
-
-    if !needs_update {
-        return Ok(false);
-    }
-
-    let mut data_to_write = match source_data {
+    let data_to_write = match source_data {
         Some(data) => data,
         None => target_data.unwrap_or_default(),
     };
@@ -457,7 +445,7 @@ fn sync_workspace_composer_index(
         return Ok(false);
     }
 
-    data_to_write = normalize_composer_data(
+    let normalized = normalize_composer_data(
         &data_to_write,
         old_uri,
         new_uri,
@@ -467,11 +455,24 @@ fn sync_workspace_composer_index(
         new_workspace_hash,
     );
 
+    let needs_update = force_index
+        || data_to_write.contains(old_uri)
+        || data_to_write.contains(old_path)
+        || data_to_write.contains(old_workspace_hash);
+
+    if !needs_update {
+        return Ok(false);
+    }
+
+    if normalized == data_to_write {
+        return Ok(false);
+    }
+
     if dry_run {
         return Ok(true);
     }
 
-    update_composer_data(&target_conn, &data_to_write)?;
+    update_composer_data(&target_conn, &normalized)?;
     Ok(true)
 }
 
@@ -507,14 +508,6 @@ fn fetch_composer_data(conn: &Connection) -> Result<Option<String>> {
     }
 }
 
-fn has_all_composers(data: &str) -> bool {
-    serde_json::from_str::<Value>(data)
-        .ok()
-        .and_then(|v| v.get("allComposers").cloned())
-        .and_then(|v| v.as_array().map(|a| !a.is_empty()))
-        .unwrap_or(false)
-}
-
 fn normalize_composer_data(
     data: &str,
     old_uri: &str,
@@ -524,9 +517,56 @@ fn normalize_composer_data(
     old_workspace_hash: &str,
     new_workspace_hash: &str,
 ) -> String {
-    data.replace(old_uri, new_uri)
-        .replace(old_path, new_path)
-        .replace(old_workspace_hash, new_workspace_hash)
+    let replacements = [
+        (old_uri, new_uri),
+        (old_path, new_path),
+        (old_workspace_hash, new_workspace_hash),
+    ];
+    normalize_text_replacements(data, &replacements)
+}
+
+fn normalize_text_replacements(data: &str, replacements: &[(&str, &str)]) -> String {
+    let replacements: Vec<(&str, &str)> = replacements
+        .iter()
+        .copied()
+        .filter(|(old, new)| old != new)
+        .collect();
+
+    if replacements.is_empty() {
+        return data.to_string();
+    }
+
+    let mut seed = 0usize;
+    let mut working = data.to_string();
+    let mut placeholder_map = Vec::new();
+
+    for (old, _) in &replacements {
+        let mut token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{seed}__");
+        while working.contains(&token)
+            || placeholder_map
+                .iter()
+                .any(|(placeholder, _)| placeholder == &token)
+        {
+            seed += 1;
+            token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{seed}__");
+        }
+
+        working = working.replace(*old, &token);
+        placeholder_map.push((token, *old));
+        seed += 1;
+    }
+
+    let mut normalized = working;
+    for (token, old) in placeholder_map {
+        if let Some((_, new)) = replacements
+            .iter()
+            .find(|(candidate_old, _)| candidate_old == &old)
+        {
+            normalized = normalized.replace(&token, new);
+        }
+    }
+
+    normalized
 }
 
 /// Create backup snapshots before mutating Cursor metadata.
@@ -822,6 +862,8 @@ fn estimate_hash_after_move(old_path: &Path, new_path: &Path) -> Result<String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
 
     #[test]
     fn test_clean_path_basic() {
@@ -877,5 +919,145 @@ mod tests {
         let uri = path_to_file_uri(&path).unwrap();
         assert!(uri.starts_with("file:///"));
         assert!(uri.contains("Users"));
+    }
+
+    #[test]
+    fn test_sync_workspace_composer_index_normalizes_when_all_composers_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let source_db = temp_dir.path().join("source.vscdb");
+        let target_db = temp_dir.path().join("target.vscdb");
+
+        let composer_payload = r#"{"allComposers":[{"id":"file:///old/project/hash_old"}]}"#;
+        let conn = Connection::open(&source_db).unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            ("composer.composerData", composer_payload),
+        )
+        .unwrap();
+        drop(conn);
+
+        let conn = Connection::open(&target_db).unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            ("composer.composerData", composer_payload),
+        )
+        .unwrap();
+        drop(conn);
+
+        let updated = sync_workspace_composer_index(
+            Some(&source_db),
+            &target_db,
+            "file:///old/project",
+            "file:///new/project",
+            "/old/project",
+            "/new/project",
+            "hash_old",
+            "hash_new",
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert!(updated);
+
+        let conn = Connection::open(&target_db).unwrap();
+        let value: String = conn
+            .query_row(
+                "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert!(value.contains("file:///new/project"));
+        assert!(value.contains("hash_new"));
+        assert!(!value.contains("file:///old/project"));
+        assert!(!value.contains("hash_old"));
+    }
+
+    #[test]
+    fn test_sync_workspace_composer_index_no_update_without_stale_references() {
+        let temp_dir = TempDir::new().unwrap();
+        let target_db = temp_dir.path().join("target.vscdb");
+
+        let composer_payload = r#"{"allComposers":[{"id":"file:///new/project/hash_new"}]}"#;
+        let conn = Connection::open(&target_db).unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            ("composer.composerData", composer_payload),
+        )
+        .unwrap();
+        drop(conn);
+
+        let updated = sync_workspace_composer_index(
+            None,
+            &target_db,
+            "file:///old/project",
+            "file:///new/project",
+            "/old/project",
+            "/new/project",
+            "hash_old",
+            "hash_new",
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert!(!updated);
+    }
+
+    #[test]
+    fn test_normalize_composer_data_avoids_uri_double_expand() {
+        let value = r#"{"allComposers":[{"id":"file:///home/user/project/hash_old","path":"/home/user/project","title":"project"}]}"#;
+
+        let normalized = normalize_composer_data(
+            value,
+            "file:///home/user/project",
+            "file:///home/user/project-copy",
+            "/home/user/project",
+            "/home/user/project-copy",
+            "hash_old",
+            "hash_new",
+        );
+
+        assert_eq!(
+            normalized,
+            r#"{"allComposers":[{"id":"file:///home/user/project-copy/hash_new","path":"/home/user/project-copy","title":"project"}]}"#
+        );
+        assert!(!normalized.contains("file:///home/user/project-copy-copy"));
+    }
+
+    #[test]
+    fn test_normalize_composer_data_handles_encoded_uri() {
+        let value = r#"{"allComposers":[{"id":"file:///home/user/my%20project/hash_old"}]}"#;
+        let normalized = normalize_composer_data(
+            value,
+            "file:///home/user/my%20project",
+            "file:///home/user/my%20project-backup",
+            "/home/user/my project",
+            "/home/user/my project-backup",
+            "hash_old",
+            "hash_new",
+        );
+
+        assert_eq!(
+            normalized,
+            r#"{"allComposers":[{"id":"file:///home/user/my%20project-backup/hash_new"}]}"#
+        );
     }
 }

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -85,7 +85,10 @@ pub fn execute(
 
     // Print summary
     println!("{}");
-    println!("{}", format!("=== Cursor Project {} Tool ===", mode).green());
+    println!(
+        "{}",
+        format!("=== Cursor Project {} Tool ===", mode).green()
+    );
     println!("{}");
     println!("Old path: {}", old_path.display());
     println!("New path: {}", new_path.display());
@@ -156,7 +159,10 @@ pub fn execute(
     println!("New workspace hash: {}", new_workspace_hash);
 
     // Step 1: Copy/Move the project folder
-    println!("{}", format!("Step 1: {} project folder...", action).green());
+    println!(
+        "{}",
+        format!("Step 1: {} project folder...", action).green()
+    );
     println!("  {} -> {}", old_path.display(), new_path.display());
     copy_or_move(&old_path, &new_path, copy_mode, dry_run)?;
 
@@ -244,25 +250,30 @@ pub fn execute(
             println!("  -> No workspace state DB found; skipping composer index sync");
         }
     } else if dry_run {
-        println!("{}", "Step 5: Composer index sync skipped in dry-run".yellow());
+        println!(
+            "{}",
+            "Step 5: Composer index sync skipped in dry-run".yellow()
+        );
     } else {
-        println!("{}", "Step 5: No workspace state DB available for sync".yellow());
+        println!(
+            "{}",
+            "Step 5: No workspace state DB available for sync".yellow()
+        );
     }
 
     // Step 6: Update storage.json
     if storage_json_path.exists() {
-        println!("{}", "Step 6: Updating globalStorage/storage.json...".green());
+        println!(
+            "{}",
+            "Step 6: Updating globalStorage/storage.json...".green()
+        );
 
         if dry_run {
-            println!(
-                "  {} Update {} -> {}",
-                "[DRY-RUN]".blue(),
-                old_uri,
-                new_uri
-            );
+            println!("  {} Update {} -> {}", "[DRY-RUN]".blue(), old_uri, new_uri);
         }
 
-        let mut modified = storage::update_storage_json(&storage_json_path, &old_uri, &new_uri, dry_run)?;
+        let mut modified =
+            storage::update_storage_json(&storage_json_path, &old_uri, &new_uri, dry_run)?;
 
         let hash_modified = old_workspace_hash != new_workspace_hash;
         if hash_modified && !dry_run {
@@ -278,8 +289,12 @@ pub fn execute(
         }
 
         if old_path_raw != new_path_raw {
-            let path_text_modified =
-                storage::update_storage_json(&storage_json_path, &old_path_raw, &new_path_raw, dry_run)?;
+            let path_text_modified = storage::update_storage_json(
+                &storage_json_path,
+                &old_path_raw,
+                &new_path_raw,
+                dry_run,
+            )?;
             modified = modified || path_text_modified;
             if path_text_modified {
                 println!("  -> Updated raw path text in storage.json");
@@ -295,15 +310,13 @@ pub fn execute(
 
     // Step 7: Update global state DB
     if global_state_db_path.exists() {
-        println!("{}", "Step 7: Updating globalStorage/state.vscdb...".green());
+        println!(
+            "{}",
+            "Step 7: Updating globalStorage/state.vscdb...".green()
+        );
 
         if dry_run {
-            println!(
-                "  {} Update {} -> {}",
-                "[DRY-RUN]".blue(),
-                old_uri,
-                new_uri
-            );
+            println!("  {} Update {} -> {}", "[DRY-RUN]".blue(), old_uri, new_uri);
             println!(
                 "  {} Update workspace hash {} -> {}",
                 "[DRY-RUN]".blue(),
@@ -346,7 +359,10 @@ pub fn execute(
     println!("{}", "Step 8: Clearing stale cache data...".green());
     if !dry_run {
         if let Ok(true) = new_workspace_dir.exists().then_some(true) {
-            clear_path(&new_workspace_dir.join("anysphere.cursor-retrieval"), dry_run)?;
+            clear_path(
+                &new_workspace_dir.join("anysphere.cursor-retrieval"),
+                dry_run,
+            )?;
         } else {
             println!("  -> No workspace cache directory for new path");
         }
@@ -396,13 +412,21 @@ fn sync_workspace_composer_index(
     force_index: bool,
     dry_run: bool,
 ) -> Result<bool> {
-    let target_conn = Connection::open(target_db_path)
-        .with_context(|| format!("Failed to open target workspace DB: {}", target_db_path.display()))?;
+    let target_conn = Connection::open(target_db_path).with_context(|| {
+        format!(
+            "Failed to open target workspace DB: {}",
+            target_db_path.display()
+        )
+    })?;
 
     let source_data = if let Some(source_db_path) = source_db_path {
         if source_db_path.exists() {
-            let source_conn = Connection::open(source_db_path)
-                .with_context(|| format!("Failed to open source workspace DB: {}", source_db_path.display()))?;
+            let source_conn = Connection::open(source_db_path).with_context(|| {
+                format!(
+                    "Failed to open source workspace DB: {}",
+                    source_db_path.display()
+                )
+            })?;
             fetch_composer_data(&source_conn)?
         } else {
             None
@@ -522,11 +546,12 @@ fn create_rename_backup(
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let backup_root = std::env::temp_dir().join(format!(
-        "cursor-helper-rename-backup-{timestamp}"
-    ));
+    let backup_root = std::env::temp_dir().join(format!("cursor-helper-rename-backup-{timestamp}"));
     fs::create_dir_all(&backup_root).with_context(|| {
-        format!("Failed to create backup directory: {}", backup_root.display())
+        format!(
+            "Failed to create backup directory: {}",
+            backup_root.display()
+        )
     })?;
 
     if old_projects_dir.exists() {
@@ -543,23 +568,25 @@ fn create_rename_backup(
 
     if storage_json_path.exists() {
         let target = backup_root.join("storage.json");
-        fs::copy(storage_json_path, &target)
-            .with_context(|| {
-                format!("Failed to backup {} to {}", storage_json_path.display(), target.display())
-            })?;
+        fs::copy(storage_json_path, &target).with_context(|| {
+            format!(
+                "Failed to backup {} to {}",
+                storage_json_path.display(),
+                target.display()
+            )
+        })?;
         println!("  Backup storage.json: {}", target.display());
     }
 
     if global_state_db_path.exists() {
         let target = backup_root.join("state.vscdb");
-        fs::copy(global_state_db_path, &target)
-            .with_context(|| {
-                format!(
-                    "Failed to backup {} to {}",
-                    global_state_db_path.display(),
-                    target.display()
-                )
-            })?;
+        fs::copy(global_state_db_path, &target).with_context(|| {
+            format!(
+                "Failed to backup {} to {}",
+                global_state_db_path.display(),
+                target.display()
+            )
+        })?;
         println!("  Backup global state DB: {}", target.display());
     }
 

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -9,22 +9,31 @@
 use anyhow::{bail, Context, Result};
 use fs_extra::dir::{self, CopyOptions};
 use owo_colors::OwoColorize;
+use rusqlite::Connection;
+use serde_json::Value;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::UNIX_EPOCH;
 use url::Url;
 
+use super::utils;
 use crate::config;
 use crate::cursor::{folder_id, storage, workspace};
 
 /// Execute the rename command
-pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -> Result<()> {
+pub fn execute(
+    old_path: &str,
+    new_path: &str,
+    dry_run: bool,
+    copy_mode: bool,
+    force_index: bool,
+) -> Result<()> {
     // Normalize and validate paths
     let old_path = normalize_path(old_path)?;
     let new_path = normalize_new_path(new_path)?;
 
-    // Validate
     if !old_path.exists() {
         bail!("Old path does not exist: {}", old_path.display());
     }
@@ -67,30 +76,30 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
 
     let old_projects_dir = cursor_projects_dir.join(&old_folder_id);
     let old_workspace_dir = workspace_storage_dir.join(&old_workspace_hash);
+    let storage_json_path = global_storage_dir.join("storage.json");
+    let global_state_db_path = global_storage_dir.join("state.vscdb");
 
     // Mode description
     let mode = if copy_mode { "COPY" } else { "MOVE" };
     let action = if copy_mode { "Copying" } else { "Moving" };
 
     // Print summary
-    println!();
-    println!(
-        "{}",
-        format!("=== Cursor Project {} Tool ===", mode).green()
-    );
-    println!();
+    println!("{}");
+    println!("{}", format!("=== Cursor Project {} Tool ===", mode).green());
+    println!("{}");
     println!("Old path: {}", old_path.display());
     println!("New path: {}", new_path.display());
     println!("Mode: {}", mode);
-    println!();
+    println!("Force index: {}", if force_index { "on" } else { "off" });
+    println!("{}", "");
     println!("Old folder ID: {}", old_folder_id);
     println!("Old workspace hash: {}", old_workspace_hash);
-    println!();
+    println!("{}", "");
 
     // Check if old data exists
     print_exists_status("Cursor projects dir", &old_projects_dir);
     print_exists_status("Workspace storage dir", &old_workspace_dir);
-    println!();
+    println!("{}");
 
     // Confirm (skip in dry-run)
     if !dry_run {
@@ -106,27 +115,37 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
         }
     }
 
-    // Step 1: Copy/Move the project folder
-    println!(
-        "{}",
-        format!("Step 1: {} project folder...", action).green()
-    );
-    println!("  {} -> {}", old_path.display(), new_path.display());
-    copy_or_move(&old_path, &new_path, copy_mode, dry_run)?;
+    // Step 0: Create backups for rollback safety
+    if dry_run {
+        println!("{}", "Step 0: Skipping backups in dry-run mode.".yellow());
+    } else {
+        println!("{}", "Step 0: Creating safety backup...".green());
+        if let Some(backup_dir) = create_rename_backup(
+            &old_projects_dir,
+            &old_workspace_dir,
+            &storage_json_path,
+            &global_state_db_path,
+            dry_run,
+        )? {
+            println!("  Backup created at: {}", backup_dir.display());
+        }
+    }
+
+    let old_uri = path_to_file_uri(&old_path)?;
+    let new_uri = path_to_file_uri(&new_path)?;
+    let old_path_raw = old_path.to_string_lossy().to_string();
+    let new_path_raw = new_path.to_string_lossy().to_string();
 
     // Compute new identifiers
     let new_folder_id = folder_id::path_to_folder_id(&new_path);
     let new_workspace_hash = if dry_run {
         if copy_mode {
-            // In copy mode with dry-run, we can't compute the hash
-            // because the new folder doesn't exist yet
             println!(
                 "  {}",
                 "(New folder would get new birthtime, hash computed at runtime)".yellow()
             );
             "<computed-at-runtime>".to_string()
         } else {
-            // Move preserves birthtime, estimate hash with new path
             estimate_hash_after_move(&old_path, &new_path)?
         }
     } else {
@@ -135,6 +154,16 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
 
     println!("New folder ID: {}", new_folder_id);
     println!("New workspace hash: {}", new_workspace_hash);
+
+    // Step 1: Copy/Move the project folder
+    println!("{}", format!("Step 1: {} project folder...", action).green());
+    println!("  {} -> {}", old_path.display(), new_path.display());
+    copy_or_move(&old_path, &new_path, copy_mode, dry_run)?;
+
+    let mut source_composer_db: Option<PathBuf> = None;
+    if copy_mode && !dry_run && old_workspace_dir.exists() {
+        source_composer_db = Some(old_workspace_dir.join("state.vscdb"));
+    }
 
     // Step 2: Copy/Move ~/.cursor/projects/
     let new_projects_dir = cursor_projects_dir.join(&new_folder_id);
@@ -173,8 +202,6 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
         let workspace_json_path = new_workspace_dir.join("workspace.json");
         println!("{}", "Step 4: Updating workspace.json...".green());
 
-        let new_uri = path_to_file_uri(&new_path)?;
-
         if dry_run {
             println!(
                 "  {} Write to {}:",
@@ -191,35 +218,152 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
         println!("{}", "Step 3: No workspaceStorage data to migrate".yellow());
     }
 
-    // Step 5: Update storage.json
-    let storage_json_path = global_storage_dir.join("storage.json");
-    if storage_json_path.exists() {
-        println!(
-            "{}",
-            "Step 5: Updating globalStorage/storage.json...".green()
-        );
+    // Step 5: Ensure composer index in workspace state DB
+    if !dry_run && new_workspace_dir.exists() {
+        let new_workspace_db = new_workspace_dir.join("state.vscdb");
+        if new_workspace_db.exists() {
+            println!("{}", "Step 5: Synchronizing composer index...".green());
+            let updated = sync_workspace_composer_index(
+                source_composer_db.as_deref(),
+                &new_workspace_db,
+                &old_uri,
+                &new_uri,
+                &old_path_raw,
+                &new_path_raw,
+                &old_workspace_hash,
+                &new_workspace_hash,
+                force_index,
+                dry_run,
+            )?;
+            if updated {
+                println!("  -> Composer index synchronized");
+            } else {
+                println!("  -> Composer index already complete");
+            }
+        } else {
+            println!("  -> No workspace state DB found; skipping composer index sync");
+        }
+    } else if dry_run {
+        println!("{}", "Step 5: Composer index sync skipped in dry-run".yellow());
+    } else {
+        println!("{}", "Step 5: No workspace state DB available for sync".yellow());
+    }
 
-        let old_uri = path_to_file_uri(&old_path)?;
-        let new_uri = path_to_file_uri(&new_path)?;
+    // Step 6: Update storage.json
+    if storage_json_path.exists() {
+        println!("{}", "Step 6: Updating globalStorage/storage.json...".green());
 
         if dry_run {
-            println!("  {} Update {} -> {}", "[DRY-RUN]".blue(), old_uri, new_uri);
+            println!(
+                "  {} Update {} -> {}",
+                "[DRY-RUN]".blue(),
+                old_uri,
+                new_uri
+            );
         }
 
-        let modified =
-            storage::update_storage_json(&storage_json_path, &old_uri, &new_uri, dry_run)?;
+        let mut modified = storage::update_storage_json(&storage_json_path, &old_uri, &new_uri, dry_run)?;
 
-        if modified {
-            println!("  -> Updated workspace references");
+        let hash_modified = old_workspace_hash != new_workspace_hash;
+        if hash_modified && !dry_run {
+            println!(
+                "  Note: storage.json hash migration skipped (format may be unsupported): {} -> {}",
+                old_workspace_hash, new_workspace_hash
+            );
+        } else if dry_run {
+            println!(
+                "  {} Hash migration in storage.json would run if needed",
+                "[DRY-RUN]".blue()
+            );
+        }
+
+        if old_path_raw != new_path_raw {
+            let path_text_modified =
+                storage::update_storage_json(&storage_json_path, &old_path_raw, &new_path_raw, dry_run)?;
+            modified = modified || path_text_modified;
+            if path_text_modified {
+                println!("  -> Updated raw path text in storage.json");
+            }
+        }
+
+        if !modified && !hash_modified {
+            println!("  -> No matching storage.json updates applied");
+        }
+    } else {
+        println!("{}", "Step 6: No storage.json file found".yellow());
+    }
+
+    // Step 7: Update global state DB
+    if global_state_db_path.exists() {
+        println!("{}", "Step 7: Updating globalStorage/state.vscdb...".green());
+
+        if dry_run {
+            println!(
+                "  {} Update {} -> {}",
+                "[DRY-RUN]".blue(),
+                old_uri,
+                new_uri
+            );
+            println!(
+                "  {} Update workspace hash {} -> {}",
+                "[DRY-RUN]".blue(),
+                old_workspace_hash,
+                new_workspace_hash
+            );
+        }
+
+        let uri_modified = storage::update_global_state_db(
+            &global_state_db_path,
+            &old_uri,
+            &new_uri,
+            &old_workspace_hash,
+            &new_workspace_hash,
+            dry_run,
+        )?;
+        let path_modified = if old_path_raw != new_path_raw {
+            storage::update_global_state_db(
+                &global_state_db_path,
+                &old_path_raw,
+                &new_path_raw,
+                &old_workspace_hash,
+                &new_workspace_hash,
+                dry_run,
+            )?
         } else {
-            println!("  -> No matching references found");
+            false
+        };
+
+        if uri_modified || path_modified {
+            println!("  -> Updated global state references");
+        } else {
+            println!("  -> No matching global state references found");
         }
+    } else {
+        println!("{}", "Step 7: No global state DB found".yellow());
+    }
+
+    // Step 8: Clear stale cache directories
+    println!("{}", "Step 8: Clearing stale cache data...".green());
+    if !dry_run {
+        if let Ok(true) = new_workspace_dir.exists().then_some(true) {
+            clear_path(&new_workspace_dir.join("anysphere.cursor-retrieval"), dry_run)?;
+        } else {
+            println!("  -> No workspace cache directory for new path");
+        }
+
+        for cache_dir in config::cursor_cache_dirs()? {
+            if cache_dir.exists() {
+                clear_path(&cache_dir, dry_run)?;
+            }
+        }
+    } else {
+        println!("  -> Cache clear skipped in dry-run");
     }
 
     // Done!
-    println!();
+    println!("{}");
     println!("{}", format!("=== {} complete! ===", mode).green());
-    println!();
+    println!("{}");
 
     if dry_run {
         println!("This was a dry-run. No changes were made.");
@@ -228,13 +372,223 @@ pub fn execute(old_path: &str, new_path: &str, dry_run: bool, copy_mode: bool) -
         println!("You can now open {} in Cursor.", new_path.display());
         println!("Your chat history and workspace settings should be preserved.");
         if copy_mode {
-            println!();
+            println!("{}");
             println!(
                 "Original project at {} was kept intact.",
                 old_path.display()
             );
         }
     }
+
+    Ok(())
+}
+
+/// Update composer index in workspace state DB when copied from an existing workspace
+fn sync_workspace_composer_index(
+    source_db_path: Option<&Path>,
+    target_db_path: &Path,
+    old_uri: &str,
+    new_uri: &str,
+    old_path: &str,
+    new_path: &str,
+    old_workspace_hash: &str,
+    new_workspace_hash: &str,
+    force_index: bool,
+    dry_run: bool,
+) -> Result<bool> {
+    let target_conn = Connection::open(target_db_path)
+        .with_context(|| format!("Failed to open target workspace DB: {}", target_db_path.display()))?;
+
+    let source_data = if let Some(source_db_path) = source_db_path {
+        if source_db_path.exists() {
+            let source_conn = Connection::open(source_db_path)
+                .with_context(|| format!("Failed to open source workspace DB: {}", source_db_path.display()))?;
+            fetch_composer_data(&source_conn)?
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let target_data = fetch_composer_data(&target_conn)?;
+
+    let target_has_all_composers = target_data
+        .as_deref()
+        .is_some_and(|data| has_all_composers(data));
+    let mut needs_update = force_index || !target_has_all_composers;
+    if source_data.is_none() && force_index {
+        needs_update = true;
+    }
+
+    if !needs_update {
+        return Ok(false);
+    }
+
+    let mut data_to_write = match source_data {
+        Some(data) => data,
+        None => target_data.unwrap_or_default(),
+    };
+
+    if data_to_write.is_empty() {
+        return Ok(false);
+    }
+
+    data_to_write = normalize_composer_data(
+        &data_to_write,
+        old_uri,
+        new_uri,
+        old_path,
+        new_path,
+        old_workspace_hash,
+        new_workspace_hash,
+    );
+
+    if dry_run {
+        return Ok(true);
+    }
+
+    update_composer_data(&target_conn, &data_to_write)?;
+    Ok(true)
+}
+
+/// Update composer.composerData in ItemTable
+fn update_composer_data(conn: &Connection, data: &str) -> Result<()> {
+    let updated = conn
+        .execute(
+            "UPDATE ItemTable SET value = ?1 WHERE key = 'composer.composerData'",
+            [data],
+        )
+        .with_context(|| "Failed to update composer.composerData")?;
+
+    if updated == 0 {
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES ('composer.composerData', ?1)",
+            [data],
+        )
+        .with_context(|| "Failed to insert composer.composerData")?;
+    }
+
+    Ok(())
+}
+
+fn fetch_composer_data(conn: &Connection) -> Result<Option<String>> {
+    match conn.query_row(
+        "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
+        [],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(value) => Ok(Some(value)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e).context("Failed to query composer.composerData"),
+    }
+}
+
+fn has_all_composers(data: &str) -> bool {
+    serde_json::from_str::<Value>(data)
+        .ok()
+        .and_then(|v| v.get("allComposers").cloned())
+        .and_then(|v| v.as_array().map(|a| !a.is_empty()))
+        .unwrap_or(false)
+}
+
+fn normalize_composer_data(
+    data: &str,
+    old_uri: &str,
+    new_uri: &str,
+    old_path: &str,
+    new_path: &str,
+    old_workspace_hash: &str,
+    new_workspace_hash: &str,
+) -> String {
+    data.replace(old_uri, new_uri)
+        .replace(old_path, new_path)
+        .replace(old_workspace_hash, new_workspace_hash)
+}
+
+/// Create backup snapshots before mutating Cursor metadata.
+fn create_rename_backup(
+    old_projects_dir: &Path,
+    old_workspace_dir: &Path,
+    storage_json_path: &Path,
+    global_state_db_path: &Path,
+    dry_run: bool,
+) -> Result<Option<PathBuf>> {
+    if dry_run {
+        return Ok(None);
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let backup_root = std::env::temp_dir().join(format!(
+        "cursor-helper-rename-backup-{timestamp}"
+    ));
+    fs::create_dir_all(&backup_root).with_context(|| {
+        format!("Failed to create backup directory: {}", backup_root.display())
+    })?;
+
+    if old_projects_dir.exists() {
+        let backup_projects = backup_root.join("old_projects");
+        utils::copy_dir(old_projects_dir, &backup_projects)?;
+        println!("  Backup projects: {}", backup_projects.display());
+    }
+
+    if old_workspace_dir.exists() {
+        let backup_workspace = backup_root.join("old_workspace");
+        utils::copy_dir(old_workspace_dir, &backup_workspace)?;
+        println!("  Backup workspaceStorage: {}", backup_workspace.display());
+    }
+
+    if storage_json_path.exists() {
+        let target = backup_root.join("storage.json");
+        fs::copy(storage_json_path, &target)
+            .with_context(|| {
+                format!("Failed to backup {} to {}", storage_json_path.display(), target.display())
+            })?;
+        println!("  Backup storage.json: {}", target.display());
+    }
+
+    if global_state_db_path.exists() {
+        let target = backup_root.join("state.vscdb");
+        fs::copy(global_state_db_path, &target)
+            .with_context(|| {
+                format!(
+                    "Failed to backup {} to {}",
+                    global_state_db_path.display(),
+                    target.display()
+                )
+            })?;
+        println!("  Backup global state DB: {}", target.display());
+    }
+
+    Ok(Some(backup_root))
+}
+
+/// Clear stale cache files or directories.
+fn clear_path(path: &Path, dry_run: bool) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "  {} Remove {} (dry-run)",
+            "[DRY-RUN]".blue(),
+            path.display()
+        );
+        return Ok(());
+    }
+
+    if path.is_dir() {
+        fs::remove_dir_all(path)
+            .with_context(|| format!("Failed to remove directory: {}", path.display()))?;
+    } else {
+        fs::remove_file(path)
+            .with_context(|| format!("Failed to remove file: {}", path.display()))?;
+    }
+    println!("  -> Removed: {}", path.display());
 
     Ok(())
 }
@@ -428,8 +782,6 @@ fn path_to_file_uri(path: &Path) -> Result<String> {
 
 /// Estimate workspace hash after a move (uses old birthtime with new path)
 fn estimate_hash_after_move(old_path: &Path, new_path: &Path) -> Result<String> {
-    use std::time::UNIX_EPOCH;
-
     let metadata = fs::metadata(old_path)?;
     let created = metadata.created()?;
     let duration = created.duration_since(UNIX_EPOCH)?;
@@ -453,14 +805,12 @@ mod tests {
 
     #[test]
     fn test_clean_path_with_current_dir() {
-        // . components should be removed
         let path = PathBuf::from("/home/./user/./project");
         assert_eq!(clean_path(&path), PathBuf::from("/home/user/project"));
     }
 
     #[test]
     fn test_clean_path_with_parent_dir() {
-        // .. should navigate up
         let path = PathBuf::from("/home/user/../admin/project");
         assert_eq!(clean_path(&path), PathBuf::from("/home/admin/project"));
     }

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -280,7 +280,7 @@ pub fn execute(
             println!("  {} Update {} -> {}", "[DRY-RUN]".blue(), old_uri, new_uri);
         }
 
-        let mut modified =
+        let modified =
             storage::update_storage_json(&storage_json_path, &old_uri, &new_uri, dry_run)?;
 
         let hash_modified = old_workspace_hash != new_workspace_hash;
@@ -294,19 +294,6 @@ pub fn execute(
                 "  {} Hash migration in storage.json would run if needed",
                 "[DRY-RUN]".blue()
             );
-        }
-
-        if old_path_raw != new_path_raw {
-            let path_text_modified = storage::update_storage_json(
-                &storage_json_path,
-                &old_path_raw,
-                &new_path_raw,
-                dry_run,
-            )?;
-            modified = modified || path_text_modified;
-            if path_text_modified {
-                println!("  -> Updated raw path text in storage.json");
-            }
         }
 
         if !modified && !hash_modified {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub fn cursor_projects_dir() -> Result<PathBuf> {
 /// - macOS: ~/Library/Application Support/Cursor/
 /// - Linux: ~/.config/Cursor/
 /// - Windows: %APPDATA%/Cursor/
-fn cursor_config_dir() -> Result<PathBuf> {
+pub fn cursor_config_dir() -> Result<PathBuf> {
     #[cfg(target_os = "macos")]
     {
         let home = dirs::home_dir().context("Could not determine home directory")?;
@@ -44,6 +44,15 @@ pub fn workspace_storage_dir() -> Result<PathBuf> {
 /// - Windows: %APPDATA%/Cursor/User/globalStorage/
 pub fn global_storage_dir() -> Result<PathBuf> {
     Ok(cursor_config_dir()?.join("User").join("globalStorage"))
+}
+
+/// Get Cursor cache directories used by the Electron shell.
+///
+/// These are used for clearing stale in-memory/cache state after copy
+/// operations to force index refresh in the running editor host.
+pub fn cursor_cache_dirs() -> Result<Vec<PathBuf>> {
+    let base = cursor_config_dir()?;
+    Ok(vec![base.join("CachedData"), base.join("GPUCache")])
 }
 
 #[cfg(test)]

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -138,6 +138,10 @@ pub fn update_global_state_db<P: AsRef<Path>>(
                 continue;
             };
 
+            if !has_workspace_scoped_reference(&value, &normalized_replacements) {
+                continue;
+            }
+
             let normalized = normalize_text_replacements(&value, &normalized_replacements);
 
             if normalized == value {
@@ -165,6 +169,50 @@ pub fn update_global_state_db<P: AsRef<Path>>(
     }
 
     Ok(modified)
+}
+
+fn has_workspace_scoped_reference(value: &str, replacements: &[(String, String)]) -> bool {
+    let candidates: Vec<&str> = replacements
+        .iter()
+        .filter_map(|(old, new)| (old != new).then_some(old.as_str()))
+        .collect();
+
+    candidates
+        .iter()
+        .any(|old| has_safe_suffix_match(value, old))
+}
+
+fn has_safe_suffix_match(value: &str, pattern: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+
+    let mut offset = 0usize;
+    while let Some(pos) = value[offset..].find(pattern) {
+        let absolute_pos = offset + pos;
+        let suffix = value[absolute_pos + pattern.len()..].chars().next();
+
+        if is_workspace_value_suffix_terminator(suffix) {
+            return true;
+        }
+
+        offset = absolute_pos + 1;
+    }
+
+    false
+}
+
+fn is_workspace_value_suffix_terminator(suffix: Option<char>) -> bool {
+    match suffix {
+        None => true,
+        Some(suffix) => {
+            !suffix.is_ascii_alphanumeric()
+                && suffix != '_'
+                && suffix != '-'
+                && suffix != '.'
+                && suffix != '%'
+        }
+    }
 }
 
 fn normalize_text_replacements(value: &str, replacements: &[(String, String)]) -> String {
@@ -496,5 +544,73 @@ mod tests {
         assert!(!item_value.contains("project-copy-copy"));
         assert!(!item_key.contains("project-copy-copy"));
         assert!(modified);
+    }
+
+    #[test]
+    fn test_update_global_state_db_does_not_modify_workspace_prefix_matches() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-prefix.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///home/user/project",
+                "meta:file:///home/user/project/hash-old",
+            ),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///home/user/projects/foo",
+                "meta:file:///home/user/projects/foo/hash-other",
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "/home/user/project",
+            "/home/user/project-copy",
+            "file:///home/user/project",
+            "file:///home/user/project-copy",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let updated_value: String = conn
+            .query_row(
+                "SELECT value FROM ItemTable WHERE key = 'workspace.key.file:///home/user/project-copy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let untouched_value: String = conn
+            .query_row(
+                "SELECT value FROM ItemTable WHERE key = 'workspace.key.file:///home/user/projects/foo'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(
+            updated_value,
+            "meta:file:///home/user/project-copy/hash-new"
+        );
+        assert_eq!(
+            untouched_value,
+            "meta:file:///home/user/projects/foo/hash-other"
+        );
     }
 }

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -236,7 +236,7 @@ fn normalize_text_replacements(value: &str, replacements: &[(String, String)]) -
             token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{token_seed}__");
         }
 
-        staged = staged.replace(old, &token);
+        staged = replace_workspace_scoped_matches(&staged, old, &token);
         tokens.push((token, *old));
         token_seed += 1;
     }
@@ -251,6 +251,34 @@ fn normalize_text_replacements(value: &str, replacements: &[(String, String)]) -
         }
     }
 
+    normalized
+}
+
+fn replace_workspace_scoped_matches(value: &str, pattern: &str, replacement: &str) -> String {
+    if pattern.is_empty() {
+        return value.to_string();
+    }
+
+    let mut offset = 0usize;
+    let mut normalized = String::with_capacity(value.len());
+
+    while let Some(pos) = value[offset..].find(pattern) {
+        let absolute_pos = offset + pos;
+
+        normalized.push_str(&value[offset..absolute_pos]);
+
+        let next_offset = absolute_pos + pattern.len();
+        let suffix = value[next_offset..].chars().next();
+        if is_workspace_value_suffix_terminator(suffix) {
+            normalized.push_str(replacement);
+        } else {
+            normalized.push_str(pattern);
+        }
+
+        offset = next_offset;
+    }
+
+    normalized.push_str(&value[offset..]);
     normalized
 }
 
@@ -612,5 +640,55 @@ mod tests {
             untouched_value,
             "meta:file:///home/user/projects/foo/hash-other"
         );
+    }
+
+    #[test]
+    fn test_update_global_state_db_does_not_corrupt_prefix_values_in_same_cell() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-prefix-cell.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///home/user/project",
+                r#"{"active":"file:///home/user/project","other":"file:///home/user/projects/foo","cache":"hash-old"}"#,
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "/home/user/project",
+            "/home/user/project-copy",
+            "file:///home/user/project",
+            "file:///home/user/project-copy",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let row_key: String = conn
+            .query_row("SELECT key FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+        let row_value: String = conn
+            .query_row("SELECT value FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(row_key, "workspace.key.file:///home/user/project-copy");
+        assert_eq!(
+            row_value,
+            r#"{"active":"file:///home/user/project-copy","other":"file:///home/user/projects/foo","cache":"hash-new"}"#
+        );
+        assert!(!row_value.contains("project-copy-copy"));
     }
 }

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -76,7 +76,8 @@ pub fn update_storage_json<P: AsRef<Path>>(
 /// Cursor stores several workspace mappings and references in the global database:
 /// - `ItemTable.value` / `ItemTable.key`
 /// - `cursorDiskKV.key` / `cursorDiskKV.value`
-/// This updates any exact path hash strings from old values to new ones, which
+///
+/// Updates any exact path/hash strings from old values to new ones, which
 /// helps keep move/copy operations from leaving stale workspace IDs behind.
 pub fn update_global_state_db<P: AsRef<Path>>(
     state_db: P,

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -79,10 +79,13 @@ pub fn update_storage_json<P: AsRef<Path>>(
 ///
 /// Updates any exact path/hash strings from old values to new ones, which
 /// helps keep move/copy operations from leaving stale workspace IDs behind.
+#[allow(clippy::too_many_arguments)]
 pub fn update_global_state_db<P: AsRef<Path>>(
     state_db: P,
     old_path: &str,
     new_path: &str,
+    old_uri: &str,
+    new_uri: &str,
     old_workspace_hash: &str,
     new_workspace_hash: &str,
     dry_run: bool,
@@ -98,12 +101,18 @@ pub fn update_global_state_db<P: AsRef<Path>>(
 
     let mut modified = false;
 
-    // Replace both path references and workspace hash references in all known text
-    // columns. This is intentionally conservative to avoid schema-specific assumptions.
+    // Replace path, URI, and workspace hash references in all known text columns.
+    // This is intentionally conservative to avoid schema-specific assumptions and
+    // avoids overlap by applying all replacements through placeholders in-memory.
     let replacements = [
         (old_path, new_path),
+        (old_uri, new_uri),
         (old_workspace_hash, new_workspace_hash),
     ];
+    let normalized_replacements: Vec<(String, String)> = replacements
+        .iter()
+        .map(|(old, new)| (old.to_string(), new.to_string()))
+        .collect();
     let targets = [
         ("ItemTable", "key"),
         ("ItemTable", "value"),
@@ -116,23 +125,85 @@ pub fn update_global_state_db<P: AsRef<Path>>(
             continue;
         }
 
-        for (old, new) in replacements {
-            if old == new {
+        let query = format!("SELECT rowid, {column} FROM {table}");
+        let mut stmt = conn.prepare(&query)?;
+        let mut rows = stmt.query([])?;
+        let mut pending_updates: Vec<(i64, String)> = Vec::new();
+
+        while let Some(row) = rows.next()? {
+            let rowid: i64 = row.get(0)?;
+            let value: Option<String> = row.get(1)?;
+
+            let Some(value) = value else {
+                continue;
+            };
+
+            let normalized = normalize_text_replacements(&value, &normalized_replacements);
+
+            if normalized == value {
                 continue;
             }
 
-            let affected = count_rows_with_reference(&conn, table, column, old)?;
-            if affected > 0 {
+            if dry_run {
                 modified = true;
+                continue;
             }
 
-            if !dry_run {
-                replace_in_column(&conn, table, column, old, new)?;
-            }
+            pending_updates.push((rowid, normalized));
+        }
+
+        for (rowid, normalized) in pending_updates {
+            conn.execute(
+                &format!("UPDATE {table} SET {column} = ?1 WHERE rowid = ?2"),
+                params![normalized, rowid],
+            )
+            .with_context(|| {
+                format!("Failed to update {table}.{column} for row {rowid} in global state DB")
+            })?;
+            modified = true;
         }
     }
 
     Ok(modified)
+}
+
+fn normalize_text_replacements(value: &str, replacements: &[(String, String)]) -> String {
+    let normalized_replacements: Vec<(&str, &str)> = replacements
+        .iter()
+        .filter_map(|(old, new)| (old != new).then_some((old.as_str(), new.as_str())))
+        .collect();
+
+    if normalized_replacements.is_empty() {
+        return value.to_string();
+    }
+
+    let mut token_seed = 0usize;
+    let mut tokens = Vec::new();
+
+    let mut staged = value.to_string();
+    for (old, _) in &normalized_replacements {
+        let mut token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{token_seed}__");
+        while staged.contains(&token) || tokens.iter().any(|(old_token, _)| old_token == &token) {
+            token_seed += 1;
+            token = format!("__CURSOR_HELPER_REPLACE_TOKEN_{token_seed}__");
+        }
+
+        staged = staged.replace(old, &token);
+        tokens.push((token, *old));
+        token_seed += 1;
+    }
+
+    let mut normalized = staged;
+    for (token, old_value) in tokens {
+        if let Some((_, new_value)) = normalized_replacements
+            .iter()
+            .find(|(old, _)| old == &old_value)
+        {
+            normalized = normalized.replace(&token, new_value);
+        }
+    }
+
+    normalized
 }
 
 fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
@@ -164,35 +235,6 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
     }
 
     Ok(false)
-}
-
-fn count_rows_with_reference(
-    conn: &Connection,
-    table: &str,
-    column: &str,
-    needle: &str,
-) -> Result<i64> {
-    let query = format!("SELECT COUNT(*) FROM {table} WHERE {column} LIKE '%' || ?1 || '%'");
-    conn.query_row(&query, params![needle], |row| row.get(0))
-        .with_context(|| format!("Failed to count references in {table}.{column}"))
-}
-
-fn replace_in_column(
-    conn: &Connection,
-    table: &str,
-    column: &str,
-    old: &str,
-    new: &str,
-) -> Result<usize> {
-    let query = format!(
-        "UPDATE {table} SET {column} = REPLACE({column}, ?1, ?2) WHERE {column} LIKE '%' || ?1 || '%'"
-    );
-
-    let replaced = conn
-        .execute(&query, params![old, new])
-        .with_context(|| format!("Failed to replace references in {table}.{column}"))?;
-
-    Ok(replaced)
 }
 
 /// A simpler representation of storage.json for reading
@@ -310,6 +352,8 @@ mod tests {
             &db_path,
             "file:///old/path",
             "file:///new/path",
+            "file:///old/path",
+            "file:///new/path",
             "hash-old",
             "hash-new",
             false,
@@ -352,5 +396,105 @@ mod tests {
         assert_eq!(item_value, "meta:file:///new/path/hash-new");
         assert_eq!(disk_key, "composer:hash-new");
         assert_eq!(disk_value, "file:///new/path");
+    }
+
+    #[test]
+    fn test_update_global_state_db_special_chars() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-special.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///old%20path%2Fwith%25percent/hash_old",
+                "meta:file:///old%20path%2Fwith%25percent",
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "file:///old%20path%2Fwith%25percent",
+            "file:///new%20path%2Fwith%25percent",
+            "file:///old%20path%2Fwith%25percent",
+            "file:///new%20path%2Fwith%25percent",
+            "hash_old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let item: (String, String) = conn
+            .query_row(
+                "SELECT key, value FROM ItemTable WHERE value LIKE 'meta:file:///new%';",
+                [],
+                |row| Ok((row.get(0).unwrap(), row.get(1).unwrap())),
+            )
+            .unwrap();
+
+        assert_eq!(
+            item.0,
+            "workspace.key.file:///new%20path%2Fwith%25percent/hash-new"
+        );
+        assert_eq!(item.1, "meta:file:///new%20path%2Fwith%25percent");
+    }
+
+    #[test]
+    fn test_update_global_state_db_path_then_uri_update_is_safe() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-order.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///home/user/project",
+                "file:///home/user/project/hash-old",
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "/home/user/project",
+            "/home/user/project-copy",
+            "file:///home/user/project",
+            "file:///home/user/project-copy",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let item_key: String = conn
+            .query_row("SELECT key FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+        let item_value: String = conn
+            .query_row("SELECT value FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(item_key, "workspace.key.file:///home/user/project-copy");
+        assert_eq!(item_value, "file:///home/user/project-copy/hash-new");
+        assert!(!item_value.contains("project-copy-copy"));
+        assert!(!item_key.contains("project-copy-copy"));
+        assert!(modified);
     }
 }

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -3,6 +3,7 @@
 //! Handles updates to ~/Library/Application Support/Cursor/User/globalStorage/storage.json
 
 use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -70,6 +71,129 @@ pub fn update_storage_json<P: AsRef<Path>>(
     Ok(modified)
 }
 
+/// Update workspace references embedded in global `state.vscdb`.
+///
+/// Cursor stores several workspace mappings and references in the global database:
+/// - `ItemTable.value` / `ItemTable.key`
+/// - `cursorDiskKV.key` / `cursorDiskKV.value`
+/// This updates any exact path hash strings from old values to new ones, which
+/// helps keep move/copy operations from leaving stale workspace IDs behind.
+pub fn update_global_state_db<P: AsRef<Path>>(
+    state_db: P,
+    old_path: &str,
+    new_path: &str,
+    old_workspace_hash: &str,
+    new_workspace_hash: &str,
+    dry_run: bool,
+) -> Result<bool> {
+    let state_db = state_db.as_ref();
+
+    if !state_db.exists() {
+        return Ok(false);
+    }
+
+    let conn = Connection::open(state_db)
+        .with_context(|| format!("Failed to open global state DB: {}", state_db.display()))?;
+
+    let mut modified = false;
+
+    // Replace both path references and workspace hash references in all known text
+    // columns. This is intentionally conservative to avoid schema-specific assumptions.
+    let replacements = [
+        (old_path, new_path),
+        (old_workspace_hash, new_workspace_hash),
+    ];
+    let targets = [
+        ("ItemTable", "key"),
+        ("ItemTable", "value"),
+        ("cursorDiskKV", "key"),
+        ("cursorDiskKV", "value"),
+    ];
+
+    for (table, column) in targets {
+        if !table_exists(&conn, table)? || !column_exists(&conn, table, column)? {
+            continue;
+        }
+
+        for (old, new) in replacements {
+            if old == new {
+                continue;
+            }
+
+            let affected = count_rows_with_reference(&conn, table, column, old)?;
+            if affected > 0 {
+                modified = true;
+            }
+
+            if !dry_run {
+                replace_in_column(&conn, table, column, old, new)?;
+            }
+        }
+    }
+
+    Ok(modified)
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?1",
+            params![table],
+            |row| row.get(0),
+        )
+        .context("Failed to query sqlite_master")?;
+
+    Ok(count > 0)
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let query = format!("PRAGMA table_info({})", table);
+    let mut stmt = conn
+        .prepare(&query)
+        .with_context(|| format!("Failed to read schema for table: {table}"))?;
+
+    let mut rows = stmt.query([]).with_context(|| format!("Failed to query columns for {table}"))?;
+    while let Some(row) = rows.next().context("Failed to iterate table info")? {
+        let col_name: String = row.get(1)?;
+        if col_name == column {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn count_rows_with_reference(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    needle: &str,
+) -> Result<i64> {
+    let query = format!(
+        "SELECT COUNT(*) FROM {table} WHERE {column} LIKE '%' || ?1 || '%'"
+    );
+    conn.query_row(&query, params![needle], |row| row.get(0))
+        .with_context(|| format!("Failed to count references in {table}.{column}"))
+}
+
+fn replace_in_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    old: &str,
+    new: &str,
+) -> Result<usize> {
+    let query = format!(
+        "UPDATE {table} SET {column} = REPLACE({column}, ?1, ?2) WHERE {column} LIKE '%' || ?1 || '%'"
+    );
+
+    let replaced = conn
+        .execute(&query, params![old, new])
+        .with_context(|| format!("Failed to replace references in {table}.{column}"))?;
+
+    Ok(replaced)
+}
+
 /// A simpler representation of storage.json for reading
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -115,6 +239,7 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+    use tempfile::TempDir;
 
     #[test]
     fn test_update_storage_json() {
@@ -147,5 +272,81 @@ mod tests {
         let content = fs::read_to_string(file.path()).unwrap();
         assert!(content.contains("file:///new/path"));
         assert!(!content.contains("file:///old/path"));
+    }
+
+    #[test]
+    fn test_update_global_state_db() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            ("workspace.key.file:///old/path", "meta:file:///old/path/hash-old"),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO cursorDiskKV(key, value) VALUES (?1, ?2)",
+            ("composer:hash-old", "file:///old/path"),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "file:///old/path",
+            "file:///new/path",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let item_key: String = conn
+            .query_row(
+                "SELECT key FROM ItemTable WHERE value LIKE '%new/path%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let item_value: String = conn
+            .query_row(
+                "SELECT value FROM ItemTable WHERE key LIKE '%new/path%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let disk_key: String = conn
+            .query_row(
+                "SELECT key FROM cursorDiskKV WHERE value LIKE '%new/path%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let disk_value: String = conn
+            .query_row(
+                "SELECT value FROM cursorDiskKV WHERE key LIKE '%hash-new%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(item_key, "workspace.key.file:///new/path");
+        assert_eq!(item_value, "meta:file:///new/path/hash-new");
+        assert_eq!(disk_key, "composer:hash-new");
+        assert_eq!(disk_value, "file:///new/path");
     }
 }

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -152,7 +152,9 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
         .prepare(&query)
         .with_context(|| format!("Failed to read schema for table: {table}"))?;
 
-    let mut rows = stmt.query([]).with_context(|| format!("Failed to query columns for {table}"))?;
+    let mut rows = stmt
+        .query([])
+        .with_context(|| format!("Failed to query columns for {table}"))?;
     while let Some(row) = rows.next().context("Failed to iterate table info")? {
         let col_name: String = row.get(1)?;
         if col_name == column {
@@ -169,9 +171,7 @@ fn count_rows_with_reference(
     column: &str,
     needle: &str,
 ) -> Result<i64> {
-    let query = format!(
-        "SELECT COUNT(*) FROM {table} WHERE {column} LIKE '%' || ?1 || '%'"
-    );
+    let query = format!("SELECT COUNT(*) FROM {table} WHERE {column} LIKE '%' || ?1 || '%'");
     conn.query_row(&query, params![needle], |row| row.get(0))
         .with_context(|| format!("Failed to count references in {table}.{column}"))
 }
@@ -292,7 +292,10 @@ mod tests {
         .unwrap();
         conn.execute(
             "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
-            ("workspace.key.file:///old/path", "meta:file:///old/path/hash-old"),
+            (
+                "workspace.key.file:///old/path",
+                "meta:file:///old/path/hash-old",
+            ),
         )
         .unwrap();
         conn.execute(

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ enum Commands {
         /// Copy instead of move (keeps original project intact)
         #[arg(short, long)]
         copy: bool,
+
+        /// Force a full composer index rebuild after copy
+        #[arg(long)]
+        force_index: bool,
     },
 
     /// List all Cursor projects
@@ -168,11 +172,12 @@ fn main() -> Result<()> {
             new_path,
             dry_run,
             copy,
+            force_index,
         } => {
             if dry_run {
                 println!("{}", "(DRY-RUN MODE - no changes will be made)".blue());
             }
-            commands::rename::execute(&old_path, &new_path, dry_run, copy)?;
+            commands::rename::execute(&old_path, &new_path, dry_run, copy, force_index)?;
         }
 
         Commands::List {


### PR DESCRIPTION
#2  Scope

This PR restores reliable `cursor-helper rename --copy` behavior so copied workspaces retain chat history visibility and related Cursor metadata is migrated safely. It adds a full-fidelity composer index path rewrite flow, safer global-state migrations, and explicit `--force-index` support.

## Changes
- `src/commands/rename.rs`
  - Added `force_index` handling through CLI-to-execution flow and surfaced it in command logs.
  - Reordered/rewrote migration sequence so destination identifiers are computed after destination creation and copy/move semantics remain correct.
  - Added `sync_workspace_composer_index` for workspace `state.vscdb` composer normalization from source DB (copy flow) or existing target data.
  - Added boundary-aware normalization so `normalize_text_replacements` only replaces scoped matches, preventing prefix collisions (e.g. `/project` vs `/projects/*`).
  - Added backup creation for Cursor metadata files before mutation and dry-run-safe behavior.
  - Cleared stale cache directories (`CachedData`, `GPUCache`, and workspace `anysphere.cursor-retrieval`) as part of stale-state cleanup.
  - Included focused regression tests for:
    - force index write-path behavior when no stale references exist,
    - URI/ path/hash normalization correctness,
    - same-cell prefix-sibling safety,
    - composer data normalization idempotency in expected cases.

- `src/cursor/storage.rs`
  - Added `update_global_state_db` to migrate workspace path/URI/hash references in `globalStorage/state.vscdb`.
  - Added safe-schema table/column checks before mutation (`ItemTable`, `cursorDiskKV` support).
  - Implemented scoped replacement engine with placeholder tokens and suffix-boundary checks to prevent accidental cross-workspace corruption.
  - Added tests for migration correctness and collision safety.

- `src/config.rs`
  - Exposed `cursor_config_dir`.
  - Added `cursor_cache_dirs` helper returning Electron cache paths used by rename cleanup.

- `README.md`
  - Documented `--force-index` usage.
  - Updated copy-flow behavior description and validation checklist for rename/copy scenarios.

- `CHANGELOG.md`
  - Added unreleased entries for `--force-index` and copy flow/global-state sync fixes.

- `.gitignore`
  - Added `.cursor/` to avoid local Cursor state artifacts in git.

## Validation
- `cargo test sync_workspace_composer -- --nocapture`
- `cargo clippy -p cursor-helper`
- Targeted tests for new normalize/update regression cases.