### PR TITLE
Fix modern Cursor chat session discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .claude/settings.local.json
 *.tar.gz
 .vscode/
+.cursor/

--- a/src/commands/export_chat.rs
+++ b/src/commands/export_chat.rs
@@ -24,6 +24,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::utils;
+use crate::cursor::chat_sessions;
 
 /// Output format for chat export
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -348,57 +349,15 @@ fn extract_chat_sessions(
     workspace_dir: &Path,
     options: &ExportOptions,
 ) -> Result<Vec<ChatSession>> {
-    let db_path = workspace_dir.join("state.vscdb");
-
-    if !db_path.exists() {
-        return Ok(vec![]);
-    }
-
-    let conn = Connection::open_with_flags(
-        &db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
-
-    // Query composer metadata from workspace storage
-    // QueryReturnedNoRows means no chat sessions exist, not an error
-    let composer_data: Option<String> = match conn.query_row(
-        "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
-        [],
-        |row| row.get(0),
-    ) {
-        Ok(data) => Some(data),
-        Err(rusqlite::Error::QueryReturnedNoRows) => None,
-        Err(e) => {
-            return Err(e).with_context(|| {
-                format!("Failed to query chat metadata from: {}", db_path.display())
-            })
-        }
-    };
-
-    // Parse composer metadata to get session info
-    let composers: Vec<ComposerInfo> = composer_data
-        .as_ref()
-        .and_then(|data| parse_composer_data(data, options.include_archived))
-        .unwrap_or_default();
+    let composers =
+        chat_sessions::discover_workspace_sessions(workspace_dir, options.include_archived)?;
 
     if composers.is_empty() {
         return Ok(vec![]);
     }
 
     // Open global storage for bubble content (optional - may not exist on all setups)
-    let global_db_path = crate::config::global_storage_dir()
-        .ok()
-        .map(|d| d.join("state.vscdb"))
-        .filter(|p| p.exists());
-
-    let global_conn = global_db_path.and_then(|path| {
-        Connection::open_with_flags(
-            &path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )
-        .ok() // Global storage is optional - proceed without messages if unavailable
-    });
+    let global_conn = chat_sessions::open_global_state_db().ok().flatten();
 
     // Build sessions with messages from global storage
     let mut sessions = Vec::new();
@@ -412,10 +371,10 @@ fn extract_chat_sessions(
 
         sessions.push(ChatSession {
             id: composer.composer_id.clone(),
-            title: Some(composer.name.clone()),
+            title: composer.title.clone(),
             messages,
-            created_at: Some(composer.created_at / 1000),
-            updated_at: Some(composer.last_updated_at / 1000),
+            created_at: composer.created_at_ms.map(|ts| ts / 1000),
+            updated_at: composer.updated_at_ms.map(|ts| ts / 1000),
         });
     }
 
@@ -619,59 +578,6 @@ fn truncate_str(s: &str, max_chars: usize) -> String {
         let truncated: String = s.chars().take(max_chars).collect();
         format!("{}...[truncated]", truncated)
     }
-}
-
-/// Composer metadata from composer.composerData
-#[derive(Debug, Clone)]
-struct ComposerInfo {
-    composer_id: String,
-    name: String,
-    created_at: i64,
-    last_updated_at: i64,
-}
-
-/// Parse composer.composerData JSON
-fn parse_composer_data(data: &str, include_archived: bool) -> Option<Vec<ComposerInfo>> {
-    let json: serde_json::Value = serde_json::from_str(data).ok()?;
-    let composers = json.get("allComposers")?.as_array()?;
-
-    let mut result = Vec::new();
-    for c in composers {
-        // Skip archived composers unless explicitly included
-        let is_archived = c
-            .get("isArchived")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        if is_archived && !include_archived {
-            continue;
-        }
-
-        // Try to parse each composer, skip if any required field is missing
-        let Some(composer_id) = c.get("composerId").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        let name = c
-            .get("name")
-            .and_then(|n| n.as_str())
-            .unwrap_or("Untitled")
-            .to_string();
-        let Some(created_at) = c.get("createdAt").and_then(|v| v.as_i64()) else {
-            continue;
-        };
-        let last_updated_at = c
-            .get("lastUpdatedAt")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(created_at);
-
-        result.push(ComposerInfo {
-            composer_id: composer_id.to_string(),
-            name,
-            created_at,
-            last_updated_at,
-        });
-    }
-
-    Some(result)
 }
 
 /// Format a single message as markdown

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -11,6 +11,13 @@ use url::Url;
 use super::utils;
 use crate::config;
 
+#[derive(Debug)]
+struct ProjectLoadWarning {
+    folder_id: String,
+    display_path: PathBuf,
+    message: String,
+}
+
 /// Remote connection type for vscode-remote:// URLs
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteType {
@@ -69,16 +76,32 @@ pub struct Project {
     /// When the project was last modified
     pub last_modified: Option<SystemTime>,
 
-    /// Number of chat sessions found
-    pub chat_count: usize,
+    /// Number of chat sessions found, if discovery succeeded
+    pub chat_count: Option<usize>,
+}
+
+#[derive(Debug, Default)]
+struct ListWarnings {
+    entries: Vec<ProjectLoadWarning>,
+}
+
+impl ListWarnings {
+    fn push(&mut self, folder_id: String, display_path: PathBuf, message: String) {
+        self.entries.push(ProjectLoadWarning {
+            folder_id,
+            display_path,
+            message,
+        });
+    }
 }
 
 /// List all Cursor projects
-pub fn list(workspace_storage_dir: PathBuf) -> Result<Vec<Project>> {
+fn list(workspace_storage_dir: PathBuf) -> Result<(Vec<Project>, ListWarnings)> {
     let mut projects = Vec::new();
+    let mut warnings = ListWarnings::default();
 
     if !workspace_storage_dir.exists() {
-        return Ok(projects);
+        return Ok((projects, warnings));
     }
 
     // Read all entries in workspace storage
@@ -135,9 +158,22 @@ pub fn list(workspace_storage_dir: PathBuf) -> Result<Vec<Project>> {
         // Get last modified time
         let last_modified = entry.metadata()?.modified().ok();
 
-        // Count chat sessions (default to 0 on error to avoid one bad project
-        // breaking the entire list - the project path is still shown)
-        let chat_count = utils::count_chat_sessions(&project_dir).unwrap_or(0);
+        let chat_count = match utils::count_chat_sessions_if_available(&project_dir) {
+            Ok(Some(count)) => Some(count),
+            Ok(None) => {
+                warnings.push(
+                    folder_id.clone(),
+                    parsed.path.clone(),
+                    "Chat discovery unavailable: no local session registry and global registry could not be read"
+                        .to_string(),
+                );
+                None
+            }
+            Err(err) => {
+                warnings.push(folder_id.clone(), parsed.path.clone(), err.to_string());
+                None
+            }
+        };
 
         projects.push(Project {
             folder_id,
@@ -155,7 +191,7 @@ pub fn list(workspace_storage_dir: PathBuf) -> Result<Vec<Project>> {
             .then_with(|| a.path.cmp(&b.path))
     });
 
-    Ok(projects)
+    Ok((projects, warnings))
 }
 
 /// Options for the list command
@@ -173,11 +209,11 @@ pub struct ListOptions {
 }
 
 /// Execute the list command and return formatted output
-pub fn execute(options: ListOptions) -> Result<String> {
+pub fn execute(options: ListOptions) -> Result<(String, Option<String>)> {
     let workspace_storage_dir = config::workspace_storage_dir()
         .context("Failed to determine workspace storage directory")?;
 
-    let mut projects = list(workspace_storage_dir)?;
+    let (mut projects, warnings) = list(workspace_storage_dir)?;
 
     // Apply filter
     if let Some(ref filter_str) = options.filter {
@@ -197,7 +233,11 @@ pub fn execute(options: ListOptions) -> Result<String> {
             projects.sort_by(|a, b| a.path.cmp(&b.path));
         }
         "chats" => {
-            projects.sort_by(|a, b| b.chat_count.cmp(&a.chat_count));
+            projects.sort_by(|a, b| {
+                b.chat_count
+                    .cmp(&a.chat_count)
+                    .then_with(|| a.path.cmp(&b.path))
+            });
         }
         _ => {
             // Default (including "modified"): already sorted by modified in list()
@@ -234,7 +274,10 @@ pub fn execute(options: ListOptions) -> Result<String> {
 
     for project in &projects {
         let path_str = project.path.to_string_lossy().to_string();
-        let chat_str = project.chat_count.to_string();
+        let chat_str = project
+            .chat_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
         let remote_str = match &project.remote {
             Some(r) => format!("{}:{}", r.remote_type, r.name),
             None => "-".to_string(),
@@ -272,7 +315,28 @@ pub fn execute(options: ListOptions) -> Result<String> {
         output.push_str(&format!("\n\n{} projects found", total_count));
     }
 
-    Ok(output)
+    let displayed_folder_ids: std::collections::HashSet<&str> = projects
+        .iter()
+        .map(|project| project.folder_id.as_str())
+        .collect();
+    let filtered_warning_entries = warnings
+        .entries
+        .into_iter()
+        .filter(|warning| displayed_folder_ids.contains(warning.folder_id.as_str()))
+        .collect::<Vec<_>>();
+    let warning_output = if filtered_warning_entries.is_empty() {
+        None
+    } else {
+        Some(
+            filtered_warning_entries
+                .iter()
+                .map(|warning| format!("- {}: {}", warning.display_path.display(), warning.message))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    };
+
+    Ok((output, warning_output))
 }
 
 /// Parsed URL result containing path and optional remote info
@@ -466,10 +530,57 @@ mod tests {
                 name: "myserver".to_string(),
             }),
             last_modified: None,
-            chat_count: 5,
+            chat_count: Some(5),
         };
         assert_eq!(project.folder_id, "abc123");
-        assert_eq!(project.chat_count, 5);
+        assert_eq!(project.chat_count, Some(5));
         assert!(project.remote.is_some());
+    }
+
+    #[test]
+    fn test_chat_count_unknown_displays_as_unknown() {
+        let project = Project {
+            folder_id: "abc123".to_string(),
+            path: PathBuf::from("/test/path"),
+            remote: None,
+            last_modified: None,
+            chat_count: None,
+        };
+
+        let chat_str = project
+            .chat_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        assert_eq!(chat_str, "unknown");
+    }
+
+    #[test]
+    fn test_sort_by_chats_places_unknown_last() {
+        let mut projects = vec![
+            Project {
+                folder_id: "a".to_string(),
+                path: PathBuf::from("/a"),
+                remote: None,
+                last_modified: None,
+                chat_count: None,
+            },
+            Project {
+                folder_id: "b".to_string(),
+                path: PathBuf::from("/b"),
+                remote: None,
+                last_modified: None,
+                chat_count: Some(2),
+            },
+        ];
+
+        projects.sort_by(|a, b| {
+            b.chat_count
+                .cmp(&a.chat_count)
+                .then_with(|| a.path.cmp(&b.path))
+        });
+
+        assert_eq!(projects[0].folder_id, "b");
+        assert_eq!(projects[1].folder_id, "a");
     }
 }

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -14,7 +14,7 @@ pub struct Stats {
     pub project_path: PathBuf,
 
     /// Number of chat sessions
-    pub chat_sessions: usize,
+    pub chat_sessions: Option<usize>,
 
     /// Size of workspace storage in bytes
     pub workspace_size: u64,
@@ -63,11 +63,13 @@ pub fn stats(project_path: Option<PathBuf>) -> Result<Stats> {
     let (workspace_size, chat_sessions, workspace_hash) = match &workspace_dir {
         Some(dir) => {
             let size = utils::calculate_dir_size(dir).unwrap_or(0);
-            let chats = utils::count_chat_sessions(dir).unwrap_or(0);
+            let chats = utils::count_chat_sessions_if_available(dir).with_context(|| {
+                format!("Failed to discover chat sessions in {}", dir.display())
+            })?;
             let hash = dir.file_name().map(|n| n.to_string_lossy().to_string());
             (size, chats, hash)
         }
-        None => (0, 0, None),
+        None => (0, Some(0), None),
     };
 
     Ok(Stats {
@@ -95,7 +97,13 @@ pub fn format_stats(stats: &Stats) -> String {
 
     lines.push(String::new()); // blank line
 
-    lines.push(format!("Chat Sessions: {}", stats.chat_sessions));
+    lines.push(format!(
+        "Chat Sessions: {}",
+        stats
+            .chat_sessions
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
     lines.push(format!(
         "Workspace Storage: {}",
         utils::format_size(stats.workspace_size)
@@ -119,8 +127,23 @@ mod tests {
     #[test]
     fn test_stats_default() {
         let stats = Stats::default();
-        assert_eq!(stats.chat_sessions, 0);
+        assert_eq!(stats.chat_sessions, None);
         assert_eq!(stats.workspace_size, 0);
         assert_eq!(stats.projects_size, 0);
+    }
+
+    #[test]
+    fn test_format_stats_unknown_chat_count() {
+        let stats = Stats {
+            project_path: PathBuf::from("/tmp/project"),
+            chat_sessions: None,
+            workspace_size: 0,
+            projects_size: 0,
+            folder_id: "folder-id".to_string(),
+            workspace_hash: None,
+        };
+
+        let formatted = format_stats(&stats);
+        assert!(formatted.contains("Chat Sessions: unknown"));
     }
 }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use fs_extra::dir::{self, CopyOptions};
-use rusqlite::Connection;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -57,67 +56,9 @@ pub fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Count chat sessions in a workspace directory by querying state.vscdb
-///
-/// Counts Composer sessions from `composer.composerData` which contain actual
-/// exportable chat content. Previously counted old `workbench.panel.aichat.*`
-/// keys which are orphaned UI references without content.
-///
-/// Returns 0 if the database doesn't exist or has no chat data.
-/// Returns an error for actual database problems (corruption, permissions).
-pub fn count_chat_sessions(workspace_dir: &Path) -> Result<usize> {
-    let db_path = workspace_dir.join("state.vscdb");
-
-    if !db_path.exists() {
-        return Ok(0);
-    }
-
-    // Open database in read-only mode
-    let conn = Connection::open_with_flags(
-        &db_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
-
-    // Get composer.composerData which contains the list of Composer sessions
-    // QueryReturnedNoRows means no chat data exists (0 sessions), not an error
-    let composer_data: Option<String> = match conn.query_row(
-        "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
-        [],
-        |row| row.get(0),
-    ) {
-        Ok(data) => Some(data),
-        Err(rusqlite::Error::QueryReturnedNoRows) => None,
-        Err(e) => {
-            return Err(e)
-                .with_context(|| format!("Failed to query chat data from: {}", db_path.display()))
-        }
-    };
-
-    let Some(data) = composer_data else {
-        return Ok(0);
-    };
-
-    // Parse JSON to count sessions
-    let json: serde_json::Value = serde_json::from_str(&data)
-        .with_context(|| format!("Corrupted chat data in: {}", db_path.display()))?;
-
-    let count = json
-        .get("allComposers")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter(|c| {
-                    // Count non-archived sessions (consistent with default export behavior)
-                    !c.get("isArchived")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false)
-                })
-                .count()
-        })
-        .unwrap_or(0);
-
-    Ok(count)
+/// Count stable sessions when discovery data is available.
+pub fn count_chat_sessions_if_available(workspace_dir: &Path) -> Result<Option<usize>> {
+    crate::cursor::chat_sessions::count_workspace_sessions_if_available(workspace_dir, false)
 }
 
 /// Calculate total size of a directory

--- a/src/cursor/chat_sessions.rs
+++ b/src/cursor/chat_sessions.rs
@@ -122,8 +122,8 @@ pub fn discover_workspace_sessions(
             }
             Err(err) => {
                 if sessions.is_empty() {
-                    if global_open_error.is_some() {
-                        return Err(global_open_error.unwrap()).context(err.to_string());
+                    if let Some(global_err) = global_open_error {
+                        return Err(global_err).context(err.to_string());
                     }
                     return Err(err);
                 }

--- a/src/cursor/chat_sessions.rs
+++ b/src/cursor/chat_sessions.rs
@@ -1,0 +1,762 @@
+//! Shared chat session discovery across Cursor storage layouts.
+
+use anyhow::{Context, Result};
+use percent_encoding::percent_decode_str;
+use rusqlite::{Connection, OptionalExtension};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const GLOBAL_HEADERS_KEY: &str = "composer.composerHeaders";
+const LOCAL_COMPOSER_DATA_KEY: &str = "composer.composerData";
+
+/// Stable session metadata used by list, stats, and export.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionMetadata {
+    pub composer_id: String,
+    pub title: Option<String>,
+    pub created_at_ms: Option<i64>,
+    pub updated_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct WorkspaceIdentity {
+    workspace_id: Option<String>,
+    folder_uri_normalized: Option<String>,
+    workspace_path_normalized: Option<String>,
+    remote_authority: Option<String>,
+    is_remote: bool,
+}
+
+impl WorkspaceIdentity {
+    fn from_workspace_dir(workspace_dir: &Path) -> Self {
+        let workspace_id = workspace_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string());
+
+        let workspace_json_path = workspace_dir.join("workspace.json");
+        if !workspace_json_path.exists() {
+            return Self {
+                workspace_id,
+                ..Self::default()
+            };
+        }
+
+        let folder_uri = fs::read_to_string(&workspace_json_path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<Value>(&content).ok())
+            .and_then(|workspace| {
+                workspace
+                    .get("folder")
+                    .and_then(|value| value.as_str())
+                    .or_else(|| workspace.get("workspace").and_then(|value| value.as_str()))
+                    .map(|value| value.to_string())
+            });
+
+        let folder_uri_normalized = folder_uri.as_deref().map(normalize_uri_for_comparison);
+        let workspace_path_normalized = folder_uri.as_deref().and_then(extract_workspace_path);
+        let remote_authority = folder_uri.as_deref().and_then(extract_uri_authority);
+        let is_remote = folder_uri
+            .as_deref()
+            .and_then(uri_scheme)
+            .is_some_and(|scheme| scheme == "vscode-remote");
+
+        Self {
+            workspace_id,
+            folder_uri_normalized,
+            workspace_path_normalized,
+            remote_authority,
+            is_remote,
+        }
+    }
+}
+
+/// Discover stable, top-level exportable sessions for a workspace.
+pub fn discover_workspace_sessions(
+    workspace_dir: &Path,
+    include_archived: bool,
+) -> Result<Vec<SessionMetadata>> {
+    let identity = WorkspaceIdentity::from_workspace_dir(workspace_dir);
+
+    let mut global_open_error = None;
+    let global_conn = match open_global_state_db() {
+        Ok(conn) => conn,
+        Err(err) => {
+            global_open_error = Some(err);
+            None
+        }
+    };
+
+    let mut sessions = Vec::new();
+    let mut local_registry_checked = false;
+    let mut local_registry_present = false;
+
+    if let Some(conn) = global_conn.as_ref() {
+        match load_global_registry_sessions(conn, &identity, include_archived) {
+            Ok(discovered) => sessions.extend(discovered),
+            Err(err) => {
+                global_open_error = Some(err);
+            }
+        }
+    }
+
+    let local_conn = match open_workspace_state_db(workspace_dir) {
+        Ok(conn) => conn,
+        Err(err) => {
+            if sessions.is_empty() {
+                if let Some(global_err) = global_open_error {
+                    return Err(global_err).context(err.to_string());
+                }
+                return Err(err);
+            }
+            None
+        }
+    };
+    if let Some(conn) = local_conn.as_ref() {
+        local_registry_checked = true;
+        match load_legacy_local_sessions(conn, include_archived) {
+            Ok(discovered) => {
+                local_registry_present = local_registry_shape_present(conn).unwrap_or(false);
+                sessions.extend(discovered);
+            }
+            Err(err) => {
+                if sessions.is_empty() {
+                    if global_open_error.is_some() {
+                        return Err(global_open_error.unwrap()).context(err.to_string());
+                    }
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    if sessions.is_empty() {
+        if local_registry_checked && local_registry_present {
+            return Ok(vec![]);
+        }
+
+        if let Some(err) = global_open_error {
+            return Err(err);
+        }
+
+        return Ok(vec![]);
+    }
+
+    dedupe_sessions(&mut sessions);
+
+    exclude_child_sessions_from_sources(global_conn.as_ref(), local_conn.as_ref(), &mut sessions);
+
+    sort_sessions(&mut sessions);
+
+    Ok(sessions)
+}
+
+/// Count stable, top-level exportable sessions for a workspace.
+pub fn count_workspace_sessions(workspace_dir: &Path, include_archived: bool) -> Result<usize> {
+    Ok(discover_workspace_sessions(workspace_dir, include_archived)?.len())
+}
+
+/// Count sessions, but treat a missing or unreadable global registry as "unknown"
+/// when there is no matching local workspace session data to inspect.
+pub fn count_workspace_sessions_if_available(
+    workspace_dir: &Path,
+    include_archived: bool,
+) -> Result<Option<usize>> {
+    match count_workspace_sessions(workspace_dir, include_archived) {
+        Ok(count) => Ok(Some(count)),
+        Err(err) if local_session_registry_shape_known(workspace_dir)? => Err(err),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Open Cursor's global `state.vscdb` if it exists.
+pub fn open_global_state_db() -> Result<Option<Connection>> {
+    let Some(db_path) = global_state_db_path()? else {
+        return Ok(None);
+    };
+
+    Ok(Some(open_read_only_db(&db_path)?))
+}
+
+fn global_state_db_path() -> Result<Option<PathBuf>> {
+    let db_path = crate::config::global_storage_dir()?.join("state.vscdb");
+    Ok(db_path.exists().then_some(db_path))
+}
+
+fn open_workspace_state_db(workspace_dir: &Path) -> Result<Option<Connection>> {
+    let db_path = workspace_dir.join("state.vscdb");
+    if !db_path.exists() {
+        return Ok(None);
+    }
+
+    Ok(Some(open_read_only_db(&db_path)?))
+}
+
+fn local_session_registry_shape_known(workspace_dir: &Path) -> Result<bool> {
+    let Some(conn) = open_workspace_state_db(workspace_dir)? else {
+        return Ok(false);
+    };
+
+    local_registry_shape_present(&conn)
+}
+
+fn local_registry_shape_present(conn: &Connection) -> Result<bool> {
+    let Some(data) = query_item_table_value(conn, LOCAL_COMPOSER_DATA_KEY)? else {
+        return Ok(false);
+    };
+
+    let json: Value =
+        serde_json::from_str(&data).context("Failed to parse workspace composer data")?;
+    Ok(json
+        .get("allComposers")
+        .and_then(|value| value.as_array())
+        .is_some())
+}
+
+fn open_read_only_db(db_path: &Path) -> Result<Connection> {
+    Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("Failed to open database: {}", db_path.display()))
+}
+
+fn load_global_registry_sessions(
+    conn: &Connection,
+    identity: &WorkspaceIdentity,
+    include_archived: bool,
+) -> Result<Vec<SessionMetadata>> {
+    let Some(data) = query_item_table_value(conn, GLOBAL_HEADERS_KEY)? else {
+        return Ok(vec![]);
+    };
+
+    parse_global_registry(&data, identity, include_archived)
+}
+
+fn load_legacy_local_sessions(
+    conn: &Connection,
+    include_archived: bool,
+) -> Result<Vec<SessionMetadata>> {
+    let Some(data) = query_item_table_value(conn, LOCAL_COMPOSER_DATA_KEY)? else {
+        return Ok(vec![]);
+    };
+
+    parse_local_registry(&data, include_archived)
+}
+
+fn query_item_table_value(conn: &Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM ItemTable WHERE key = ?1",
+        rusqlite::params![key],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .with_context(|| format!("Failed to query ItemTable for key: {}", key))
+}
+
+fn query_cursor_disk_value(conn: &Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM cursorDiskKV WHERE key = ?1",
+        rusqlite::params![key],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .with_context(|| format!("Failed to query cursorDiskKV for key: {}", key))
+}
+
+fn parse_global_registry(
+    data: &str,
+    identity: &WorkspaceIdentity,
+    include_archived: bool,
+) -> Result<Vec<SessionMetadata>> {
+    let json: Value =
+        serde_json::from_str(data).context("Failed to parse global composer headers")?;
+    let Some(composers) = json.get("allComposers").and_then(|value| value.as_array()) else {
+        return Ok(vec![]);
+    };
+
+    Ok(composers
+        .iter()
+        .filter(|value| session_matches_workspace(value, identity))
+        .filter_map(|value| parse_session_metadata(value, include_archived))
+        .collect())
+}
+
+fn parse_local_registry(data: &str, include_archived: bool) -> Result<Vec<SessionMetadata>> {
+    let json: Value =
+        serde_json::from_str(data).context("Failed to parse workspace composer data")?;
+    let Some(composers) = json.get("allComposers").and_then(|value| value.as_array()) else {
+        return Ok(vec![]);
+    };
+
+    Ok(composers
+        .iter()
+        .filter_map(|value| parse_session_metadata(value, include_archived))
+        .collect())
+}
+
+fn parse_session_metadata(value: &Value, include_archived: bool) -> Option<SessionMetadata> {
+    let is_archived = value
+        .get("isArchived")
+        .and_then(|flag| flag.as_bool())
+        .unwrap_or(false);
+    if is_archived && !include_archived {
+        return None;
+    }
+
+    let composer_id = value.get("composerId").and_then(|v| v.as_str())?;
+    let created_at_ms = value.get("createdAt").and_then(|v| v.as_i64());
+    let updated_at_ms = value
+        .get("lastUpdatedAt")
+        .and_then(|v| v.as_i64())
+        .or(created_at_ms);
+    let title = value
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(|name| name.to_string());
+
+    Some(SessionMetadata {
+        composer_id: composer_id.to_string(),
+        title,
+        created_at_ms,
+        updated_at_ms,
+    })
+}
+
+fn session_matches_workspace(value: &Value, identity: &WorkspaceIdentity) -> bool {
+    let actual_id = value
+        .pointer("/workspaceIdentifier/id")
+        .and_then(|v| v.as_str());
+    if let (Some(expected_id), Some(actual_id)) = (identity.workspace_id.as_deref(), actual_id) {
+        if expected_id == actual_id {
+            return true;
+        }
+    }
+
+    let actual_uri = value
+        .pointer("/workspaceIdentifier/uri/external")
+        .and_then(|v| v.as_str());
+    if let (Some(expected_uri), Some(actual_uri)) =
+        (identity.folder_uri_normalized.as_deref(), actual_uri)
+    {
+        if expected_uri == normalize_uri_for_comparison(actual_uri) {
+            return true;
+        }
+    }
+
+    if identity.is_remote {
+        if let (
+            Some(expected_authority),
+            Some(expected_path),
+            Some(actual_authority),
+            Some(actual_path),
+        ) = (
+            identity.remote_authority.as_deref(),
+            identity.workspace_path_normalized.as_deref(),
+            value
+                .pointer("/workspaceIdentifier/uri/authority")
+                .and_then(|v| v.as_str()),
+            value
+                .pointer("/workspaceIdentifier/uri/path")
+                .and_then(|v| v.as_str()),
+        ) {
+            if expected_authority == actual_authority
+                && expected_path == normalize_workspace_path(actual_path)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    if let (Some(expected_path), Some(actual_path)) = (
+        identity.workspace_path_normalized.as_deref(),
+        value
+            .pointer("/workspaceIdentifier/uri/path")
+            .and_then(|v| v.as_str()),
+    ) {
+        if expected_path == normalize_workspace_path(actual_path) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn dedupe_sessions(sessions: &mut Vec<SessionMetadata>) {
+    let mut deduped = HashMap::<String, SessionMetadata>::new();
+
+    for session in sessions.drain(..) {
+        deduped
+            .entry(session.composer_id.clone())
+            .and_modify(|existing| merge_session_metadata(existing, &session))
+            .or_insert(session);
+    }
+
+    sessions.extend(deduped.into_values());
+}
+
+fn merge_session_metadata(existing: &mut SessionMetadata, incoming: &SessionMetadata) {
+    if existing.title.is_none() {
+        existing.title = incoming.title.clone();
+    }
+
+    existing.created_at_ms = match (existing.created_at_ms, incoming.created_at_ms) {
+        (Some(lhs), Some(rhs)) => Some(lhs.min(rhs)),
+        (None, Some(rhs)) => Some(rhs),
+        (value, None) => value,
+    };
+
+    existing.updated_at_ms = match (existing.updated_at_ms, incoming.updated_at_ms) {
+        (Some(lhs), Some(rhs)) => Some(lhs.max(rhs)),
+        (None, Some(rhs)) => Some(rhs),
+        (value, None) => value,
+    };
+}
+
+fn exclude_child_sessions_from_sources(
+    global_conn: Option<&Connection>,
+    local_conn: Option<&Connection>,
+    sessions: &mut Vec<SessionMetadata>,
+) {
+    if sessions.len() <= 1 {
+        return;
+    }
+
+    let mut child_ids = HashSet::new();
+    if let Some(conn) = global_conn {
+        collect_child_ids_for_sessions(conn, sessions, &mut child_ids);
+    }
+    if let Some(conn) = local_conn {
+        collect_child_ids_for_sessions(conn, sessions, &mut child_ids);
+    }
+
+    if child_ids.is_empty() {
+        return;
+    }
+
+    sessions.retain(|session| !child_ids.contains(&session.composer_id));
+}
+
+fn collect_child_ids_for_sessions(
+    conn: &Connection,
+    sessions: &[SessionMetadata],
+    child_ids: &mut HashSet<String>,
+) {
+    let session_ids: HashSet<String> = sessions
+        .iter()
+        .map(|session| session.composer_id.clone())
+        .collect();
+
+    for session_id in &session_ids {
+        let composer_key = format!("composerData:{}", session_id);
+        let Some(data) = query_cursor_disk_value(conn, &composer_key).ok().flatten() else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+
+        collect_child_ids(json.get("subComposerIds"), &session_ids, child_ids);
+        collect_child_ids(json.get("subagentComposerIds"), &session_ids, child_ids);
+    }
+}
+
+fn collect_child_ids(
+    value: Option<&Value>,
+    known_sessions: &HashSet<String>,
+    child_ids: &mut HashSet<String>,
+) {
+    let Some(entries) = value.and_then(|v| v.as_array()) else {
+        return;
+    };
+
+    for entry in entries {
+        let Some(child_id) = entry.as_str() else {
+            continue;
+        };
+        if known_sessions.contains(child_id) {
+            child_ids.insert(child_id.to_string());
+        }
+    }
+}
+
+fn sort_sessions(sessions: &mut [SessionMetadata]) {
+    sessions.sort_by(|a, b| {
+        b.updated_at_ms
+            .cmp(&a.updated_at_ms)
+            .then_with(|| b.created_at_ms.cmp(&a.created_at_ms))
+            .then_with(|| a.composer_id.cmp(&b.composer_id))
+    });
+}
+
+fn extract_workspace_path(uri: &str) -> Option<String> {
+    split_uri(uri).map(|(_, _, path)| normalize_workspace_path(&path))
+}
+
+fn uri_scheme(uri: &str) -> Option<String> {
+    split_uri(uri).map(|(scheme, _, _)| scheme.to_string())
+}
+
+fn normalize_workspace_path(path: &str) -> String {
+    let trimmed = path
+        .trim_end_matches('/')
+        .replace("%3A", ":")
+        .replace("%3a", ":");
+    let decoded = percent_decode_str(&trimmed).decode_utf8_lossy();
+    normalize_drive_letter(&decoded)
+}
+
+fn normalize_uri_for_comparison(uri: &str) -> String {
+    let trimmed = uri.trim_end_matches('/');
+    let Some((scheme, authority, path)) = split_uri(trimmed) else {
+        return trimmed.replace("%3A", ":").replace("%3a", ":");
+    };
+
+    let path = normalize_workspace_path(&path);
+
+    if authority.is_empty() {
+        format!("{}://{}", scheme.to_ascii_lowercase(), path)
+    } else {
+        format!("{}://{}{}", scheme.to_ascii_lowercase(), authority, path)
+    }
+}
+
+fn extract_uri_authority(uri: &str) -> Option<String> {
+    let (_, authority, _) = split_uri(uri)?;
+    (!authority.is_empty()).then_some(authority)
+}
+
+fn split_uri(uri: &str) -> Option<(&str, String, String)> {
+    let (scheme, rest) = uri.split_once("://")?;
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, ""),
+    };
+
+    Some((scheme, authority.to_string(), path.to_string()))
+}
+
+fn normalize_drive_letter(path: &str) -> String {
+    let mut chars: Vec<char> = path.chars().collect();
+
+    let drive_index = match chars.as_slice() {
+        ['/', drive, ':', '/', ..] if drive.is_ascii_alphabetic() => Some(1),
+        [drive, ':', '/', ..] if drive.is_ascii_alphabetic() => Some(0),
+        _ => None,
+    };
+
+    if let Some(index) = drive_index {
+        chars[index] = chars[index].to_ascii_lowercase();
+        chars.into_iter().collect()
+    } else {
+        path.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_item(conn: &Connection, key: &str, value: &str) {
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+            rusqlite::params![key, value],
+        )
+        .unwrap();
+    }
+
+    fn insert_disk_value(conn: &Connection, key: &str, value: &str) {
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![key, value],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn parse_global_registry_matches_local_workspace_by_id() {
+        let headers = r#"{
+            "allComposers": [
+                {
+                    "composerId": "session-a",
+                    "name": "Main",
+                    "createdAt": 1000,
+                    "lastUpdatedAt": 2000,
+                    "isArchived": false,
+                    "workspaceIdentifier": {
+                        "id": "workspace-1",
+                        "uri": {
+                            "external": "file:///tmp/Project"
+                        }
+                    }
+                },
+                {
+                    "composerId": "session-b",
+                    "name": "Other",
+                    "createdAt": 1000,
+                    "lastUpdatedAt": 2000,
+                    "isArchived": false,
+                    "workspaceIdentifier": {
+                        "id": "workspace-2",
+                        "uri": {
+                            "external": "file:///tmp/Other"
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        let identity = WorkspaceIdentity {
+            workspace_id: Some("workspace-1".to_string()),
+            folder_uri_normalized: Some(normalize_uri_for_comparison("file:///tmp/Project")),
+            workspace_path_normalized: Some(normalize_workspace_path("/tmp/Project")),
+            remote_authority: None,
+            is_remote: false,
+        };
+
+        let sessions = parse_global_registry(headers, &identity, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].composer_id, "session-a");
+    }
+
+    #[test]
+    fn remote_workspace_requires_matching_authority_and_path() {
+        let identity = WorkspaceIdentity {
+            workspace_id: Some("workspace-remote".to_string()),
+            folder_uri_normalized: Some(normalize_uri_for_comparison(
+                "vscode-remote://ssh-remote%2Bhost-a/home/user/project",
+            )),
+            workspace_path_normalized: Some(normalize_workspace_path("/home/user/project")),
+            remote_authority: Some("ssh-remote%2Bhost-a".to_string()),
+            is_remote: true,
+        };
+
+        let matching = serde_json::json!({
+            "workspaceIdentifier": {
+                "uri": {
+                    "authority": "ssh-remote%2Bhost-a",
+                    "path": "/home/user/project"
+                }
+            }
+        });
+        let wrong_host = serde_json::json!({
+            "workspaceIdentifier": {
+                "uri": {
+                    "authority": "ssh-remote%2Bhost-b",
+                    "path": "/home/user/project"
+                }
+            }
+        });
+
+        assert!(session_matches_workspace(&matching, &identity));
+        assert!(!session_matches_workspace(&wrong_host, &identity));
+    }
+
+    #[test]
+    fn dedupes_global_and_local_sessions_and_prefers_richer_metadata() {
+        let mut sessions = vec![
+            SessionMetadata {
+                composer_id: "session-a".to_string(),
+                title: None,
+                created_at_ms: Some(2000),
+                updated_at_ms: Some(3000),
+            },
+            SessionMetadata {
+                composer_id: "session-a".to_string(),
+                title: Some("Recovered title".to_string()),
+                created_at_ms: Some(1000),
+                updated_at_ms: Some(4000),
+            },
+        ];
+
+        dedupe_sessions(&mut sessions);
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].title.as_deref(), Some("Recovered title"));
+        assert_eq!(sessions[0].created_at_ms, Some(1000));
+        assert_eq!(sessions[0].updated_at_ms, Some(4000));
+    }
+
+    #[test]
+    fn exclude_child_sessions_works_with_local_cursor_disk_kv() {
+        let conn = init_test_db();
+        insert_disk_value(
+            &conn,
+            "composerData:parent",
+            r#"{"subagentComposerIds":["child"]}"#,
+        );
+
+        let mut sessions = vec![
+            SessionMetadata {
+                composer_id: "parent".to_string(),
+                title: Some("Parent".to_string()),
+                created_at_ms: Some(1000),
+                updated_at_ms: Some(2000),
+            },
+            SessionMetadata {
+                composer_id: "child".to_string(),
+                title: Some("Child".to_string()),
+                created_at_ms: Some(1000),
+                updated_at_ms: Some(2000),
+            },
+        ];
+
+        exclude_child_sessions_from_sources(None, Some(&conn), &mut sessions);
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].composer_id, "parent");
+    }
+
+    #[test]
+    fn local_registry_ignores_migrated_ui_state_without_all_composers() {
+        let conn = init_test_db();
+        insert_item(
+            &conn,
+            LOCAL_COMPOSER_DATA_KEY,
+            r#"{"selectedComposerIds":["session-a"],"hasMigratedComposerData":true}"#,
+        );
+
+        let sessions = load_legacy_local_sessions(&conn, false).unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn normalize_uri_preserves_case_for_posix_paths() {
+        assert_eq!(
+            normalize_uri_for_comparison("file:///tmp/Project"),
+            "file:///tmp/Project"
+        );
+        assert_ne!(
+            normalize_uri_for_comparison("file:///tmp/Project"),
+            normalize_uri_for_comparison("file:///tmp/project")
+        );
+    }
+
+    #[test]
+    fn normalize_uri_lowercases_only_windows_drive_letter() {
+        assert_eq!(
+            normalize_uri_for_comparison("file:///C%3A/Users/me/Project"),
+            "file:///c:/Users/me/Project"
+        );
+    }
+}

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,5 +1,6 @@
 //! Core Cursor IDE operations
 
+pub mod chat_sessions;
 pub mod folder_id;
 pub mod storage;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,10 @@ fn main() -> Result<()> {
                 filter,
                 limit,
             };
-            let output = commands::list::execute(options)?;
+            let (output, warnings) = commands::list::execute(options)?;
+            if let Some(warnings) = warnings {
+                eprintln!("Warnings:\n{}", warnings);
+            }
             println!("{}", output);
         }
 


### PR DESCRIPTION
## Summary

Cursor no longer reliably lists sessions with global `state.vscdb`

Instead of ad-hoc brittle heuristics and chasing Curors bad engineering design decisions for each new version, this PR introduces a centralized approach to ensuring the current version of Cursor and all future versions work within sane implementations. 

If code changes are needed, they have low surface area impact - as the impl is now centralized. 

Apologies for the large PR. 

I have validated and tested the implementation on my local machines, but a proper validation across windows and macos is still a good idea.

- discover chat sessions from global `composer.composerHeaders`, with legacy workspace-local fallback
- unify `export-chat`, `list`, and `stats` on the same session discovery path
- surface unknown chat counts explicitly instead of silently returning `0`