### PR TITLE
fix: handle blob state rows and safe renames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +253,7 @@ dependencies = [
  "fs_extra",
  "md5",
  "owo-colors",
+ "parcopy",
  "percent-encoding",
  "rusqlite",
  "serde",
@@ -280,6 +306,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
@@ -669,6 +701,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
+name = "parcopy"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e77f11133cc7033cce81e46f679506164460a770c2d18458601fcd5402f4eab"
+dependencies = [
+ "filetime",
+ "libc",
+ "rayon",
+ "tempfile",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +781,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1146,6 +1212,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1243,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -1187,6 +1285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1317,15 @@ name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cursor-helper"
 version = "0.2.2"
 edition = "2021"
+rust-version = "1.88"
 description = "CLI helper for Cursor IDE operations not exposed in the UI"
 license = "MIT"
 repository = "https://github.com/lucifer1004/cursor-helper"
@@ -20,6 +21,7 @@ md5 = "0.8"
 # Paths and directories
 dirs = "6"
 fs_extra = "1"
+parcopy = "0.3.2"
 
 # Error handling
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd cursor-helper
 cargo install --path .
 ```
 
-Requires Rust 1.70+. Works on macOS, Linux, and Windows.
+Requires Rust 1.88+. Works on macOS, Linux, and Windows.
 
 Pre-built binaries for major platforms are available on the [Releases](https://github.com/lucifer1004/cursor-helper/releases) page.
 

--- a/gov/work/2026-05-23-harden-pr-8-staged-rename-moves.toml
+++ b/gov/work/2026-05-23-harden-pr-8-staged-rename-moves.toml
@@ -1,0 +1,66 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-05-23-001"
+title = "Harden PR #8 staged rename moves"
+status = "done"
+created = "2026-05-23"
+started = "2026-05-23"
+completed = "2026-05-23"
+refs = [
+    "RFC-0000",
+    "RFC-0001",
+]
+
+[content]
+description = "Complete PR #8 hardening for rename move/copy safety: update the actual MSRV declaration and README, use parcopy for cross-device staging copy, and remove panicable production code while preserving Cursor metadata safety guarantees covered by RFC-0000/RFC-0001."
+notes = [
+    "Actual MSRV was determined from dependency/build behavior, not the stale README claim; use Rust 1.88.0 as the locked release validation floor for this PR.",
+    "Production panic cleanup excludes #[cfg(test)] modules; test-only unwraps and panics are intentionally left outside this scope.",
+    "No RFC or ADR update was required because this hardens existing RFC-0000/RFC-0001 rename safety behavior without adding new command semantics.",
+]
+
+[[content.journal]]
+date = "2026-05-23"
+scope = "implementation"
+content = "Implemented PR #8 branch update in commit 7d9e99b: declared rust-version 1.88, updated README MSRV, introduced parcopy for cross-device staging copy, and removed production panicable code paths."
+
+[[content.journal]]
+date = "2026-05-23"
+scope = "validation"
+content = "Release validation passed locally: cargo +1.88.0 test --release --locked; cargo build --release; cargo test --release; cargo clippy --release --all-targets -- -D warnings; production-only clippy panic gate; git diff --check."
+
+[[content.journal]]
+date = "2026-05-23"
+scope = "github"
+content = "PR #8 was pushed to ZanzyTHEbar/fix/blob-state-safe-rename at 7d9e99b and GitHub checks passed: CI, pre-commit, macOS build, and Windows build."
+
+[[content.acceptance_criteria]]
+text = "Cross-device rename staging copy uses parcopy while preserving source-intact failure behavior"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "Production code has no unwrap, expect, panic, or unreachable paths under release clippy gate"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "Project MSRV is declared in Cargo.toml and documented in README as Rust 1.88"
+status = "done"
+category = "changed"
+
+[[content.acceptance_criteria]]
+text = "Release build, tests, and clippy pass locally"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "GitHub PR #8 checks pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -177,7 +177,7 @@ fn find_orphaned_workspaces(workspace_storage_dir: &PathBuf) -> Result<Vec<Orpha
     }
 
     // Sort by size (largest first)
-    orphaned.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+    orphaned.sort_by_key(|entry| std::cmp::Reverse(entry.size_bytes));
 
     Ok(orphaned)
 }

--- a/src/commands/export_chat.rs
+++ b/src/commands/export_chat.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 
 use super::utils;
 use crate::cursor::chat_sessions;
+use crate::cursor::sqlite_value::query_optional_utf8_value;
 
 /// Output format for chat export
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -393,13 +394,14 @@ fn fetch_session_messages(
     let composer_key = format!("composerData:{}", composer_id);
 
     // Get composer data (stored as TEXT in cursorDiskKV)
-    let composer_str: String = match conn.query_row(
+    let Some(composer_str) = query_optional_utf8_value(
+        conn,
         "SELECT value FROM cursorDiskKV WHERE key = ?1",
-        rusqlite::params![&composer_key],
-        |row| row.get::<_, String>(0),
-    ) {
-        Ok(s) => s,
-        Err(_) => return Ok(vec![]), // Session not found in global storage
+        &composer_key,
+    )
+    .ok()
+    .flatten() else {
+        return Ok(vec![]);
     };
 
     let composer_data: serde_json::Value = serde_json::from_str(&composer_str)?;
@@ -422,13 +424,13 @@ fn fetch_session_messages(
 
         // Fetch bubble content
         let bubble_key = format!("bubbleId:{}:{}", composer_id, bubble_id);
-        let bubble_str: Option<String> = conn
-            .query_row(
-                "SELECT value FROM cursorDiskKV WHERE key = ?",
-                [&bubble_key],
-                |row| row.get(0),
-            )
-            .ok();
+        let bubble_str = query_optional_utf8_value(
+            conn,
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            &bubble_key,
+        )
+        .ok()
+        .flatten();
 
         if let Some(json_str) = bubble_str {
             if let Ok(bubble) = serde_json::from_str::<serde_json::Value>(&json_str) {

--- a/src/commands/export_chat.rs
+++ b/src/commands/export_chat.rs
@@ -273,17 +273,8 @@ pub fn execute_by_id(
 
     // Try to read the project path from workspace.json
     let project_path = {
-        let workspace_json = workspace_dir.join("workspace.json");
-        if workspace_json.exists() {
-            let content = fs::read_to_string(&workspace_json)?;
-            let ws: serde_json::Value = serde_json::from_str(&content)?;
-            ws.get("folder")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("workspace:{}", workspace_id))
-        } else {
-            format!("workspace:{}", workspace_id)
-        }
+        crate::cursor::workspace::read_workspace_target_uri(&workspace_dir)?
+            .unwrap_or_else(|| format!("workspace:{}", workspace_id))
     };
 
     // Extract chat sessions
@@ -773,6 +764,7 @@ fn format_timestamp(ts: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_export_format() {
@@ -938,5 +930,108 @@ mod tests {
         assert!(result.contains("[completed]"));
         assert!(result.contains("Parameters"));
         assert!(result.contains("Result"));
+    }
+
+    #[test]
+    fn test_execute_by_id_uses_multi_root_workspace_label() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_storage = temp_dir
+            .path()
+            .join("Cursor")
+            .join("User")
+            .join("workspaceStorage");
+        let workspace_dir = workspace_storage.join("abc123");
+        let workspace_file = temp_dir.path().join("dev.code-workspace");
+
+        fs::create_dir_all(&workspace_dir).unwrap();
+        fs::write(&workspace_file, "{}\n").unwrap();
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            format!(
+                r#"{{"workspace":"{}"}}"#,
+                url::Url::from_file_path(&workspace_file).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let export_project_path =
+            crate::cursor::workspace::read_workspace_target_uri(&workspace_dir)
+                .unwrap()
+                .unwrap_or_else(|| "workspace:abc123".to_string());
+
+        assert_eq!(
+            export_project_path,
+            url::Url::from_file_path(&workspace_file)
+                .unwrap()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_execute_by_id_exports_multi_root_workspace_label() {
+        let temp_dir = TempDir::new().unwrap();
+        let original = std::env::var_os("XDG_CONFIG_HOME");
+        let workspace_storage = temp_dir
+            .path()
+            .join("Cursor")
+            .join("User")
+            .join("workspaceStorage");
+        let workspace_dir = workspace_storage.join("abc123");
+        let workspace_file = temp_dir.path().join("dev.code-workspace");
+        let output = temp_dir.path().join("export.json");
+
+        fs::create_dir_all(&workspace_dir).unwrap();
+        fs::write(&workspace_file, "{}\n").unwrap();
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            format!(
+                r#"{{"workspace":"{}"}}"#,
+                url::Url::from_file_path(&workspace_file).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let conn = Connection::open(workspace_dir.join("state.vscdb")).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+            rusqlite::params![
+                "composer.composerData",
+                r#"{"allComposers":[{"composerId":"session-a","name":"Test","createdAt":1000,"lastUpdatedAt":2000,"isArchived":false}]}"#
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        let result = execute_by_id(
+            "abc123",
+            ExportFormat::Json,
+            Some(output.to_str().unwrap()),
+            &ExportOptions::default(),
+            false,
+        );
+
+        if let Some(value) = original {
+            std::env::set_var("XDG_CONFIG_HOME", value);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        result.unwrap();
+        let export: ChatExport =
+            serde_json::from_str(&fs::read_to_string(output).unwrap()).unwrap();
+        assert_eq!(
+            export.project_path,
+            url::Url::from_file_path(&workspace_file)
+                .unwrap()
+                .to_string()
+        );
+        assert_eq!(export.sessions.len(), 1);
+        assert_eq!(export.sessions[0].id, "session-a");
     }
 }

--- a/src/commands/export_chat.rs
+++ b/src/commands/export_chat.rs
@@ -261,6 +261,24 @@ pub fn execute_by_id(
     split: bool,
 ) -> Result<()> {
     let workspace_storage_dir = crate::config::workspace_storage_dir()?;
+    execute_by_id_from_storage(
+        &workspace_storage_dir,
+        workspace_id,
+        format,
+        output,
+        options,
+        split,
+    )
+}
+
+fn execute_by_id_from_storage(
+    workspace_storage_dir: &Path,
+    workspace_id: &str,
+    format: ExportFormat,
+    output: Option<&str>,
+    options: &ExportOptions,
+    split: bool,
+) -> Result<()> {
     let workspace_dir = workspace_storage_dir.join(workspace_id);
 
     if !workspace_dir.exists() {
@@ -371,7 +389,7 @@ fn extract_chat_sessions(
     }
 
     // Sort by creation time (newest first)
-    sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.created_at));
 
     Ok(sessions)
 }
@@ -970,12 +988,7 @@ mod tests {
     #[test]
     fn test_execute_by_id_exports_multi_root_workspace_label() {
         let temp_dir = TempDir::new().unwrap();
-        let original = std::env::var_os("XDG_CONFIG_HOME");
-        let workspace_storage = temp_dir
-            .path()
-            .join("Cursor")
-            .join("User")
-            .join("workspaceStorage");
+        let workspace_storage = temp_dir.path().join("workspaceStorage");
         let workspace_dir = workspace_storage.join("abc123");
         let workspace_file = temp_dir.path().join("dev.code-workspace");
         let output = temp_dir.path().join("export.json");
@@ -1007,22 +1020,16 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
-        let result = execute_by_id(
+        execute_by_id_from_storage(
+            &workspace_storage,
             "abc123",
             ExportFormat::Json,
             Some(output.to_str().unwrap()),
             &ExportOptions::default(),
             false,
-        );
+        )
+        .unwrap();
 
-        if let Some(value) = original {
-            std::env::set_var("XDG_CONFIG_HOME", value);
-        } else {
-            std::env::remove_var("XDG_CONFIG_HOME");
-        }
-
-        result.unwrap();
         let export: ChatExport =
             serde_json::from_str(&fs::read_to_string(output).unwrap()).unwrap();
         assert_eq!(

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -123,24 +123,16 @@ fn list(workspace_storage_dir: PathBuf) -> Result<(Vec<Project>, ListWarnings)> 
             continue;
         }
 
-        let content = fs::read_to_string(&workspace_json_path)
-            .with_context(|| format!("Failed to read: {}", workspace_json_path.display()))?;
-
-        // Parse workspace.json
-        let workspace: serde_json::Value = serde_json::from_str(&content)
-            .with_context(|| format!("Failed to parse: {}", workspace_json_path.display()))?;
-
         // workspace.json can have either:
         // - "folder": single-folder project
         // - "workspace": multi-root .code-workspace file
-        let folder_url = match workspace.get("folder").and_then(|v| v.as_str()) {
-            Some(url) => url,
-            None => {
-                // Multi-root workspace - skip for now (would need to parse .code-workspace)
-                // Could also use workspace.get("workspace") to show the workspace file
-                continue;
-            }
+        let target_uri = match crate::cursor::workspace::read_workspace_target_uri(&project_dir)
+            .with_context(|| format!("Failed to load: {}", workspace_json_path.display()))?
+        {
+            Some(uri) => uri,
+            None => continue,
         };
+        let folder_url = target_uri.as_str();
 
         // Parse folder URL
         let parsed = match parse_folder_url(folder_url) {
@@ -395,6 +387,7 @@ fn parse_folder_url(url_str: &str) -> Option<ParsedUrl> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[cfg(not(windows))]
     #[test]
@@ -425,6 +418,17 @@ mod tests {
     fn test_parse_local_url_with_spaces_windows() {
         let parsed = parse_folder_url("file:///C:/Users/me/my%20project").unwrap();
         assert_eq!(parsed.path, PathBuf::from("C:\\Users\\me\\my project"));
+        assert!(parsed.remote.is_none());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_parse_local_workspace_file_url() {
+        let parsed = parse_folder_url("file:///Users/me/projects/dev.code-workspace").unwrap();
+        assert_eq!(
+            parsed.path,
+            PathBuf::from("/Users/me/projects/dev.code-workspace")
+        );
         assert!(parsed.remote.is_none());
     }
 
@@ -582,5 +586,32 @@ mod tests {
 
         assert_eq!(projects[0].folder_id, "b");
         assert_eq!(projects[1].folder_id, "a");
+    }
+
+    #[test]
+    fn test_list_includes_multi_root_workspace_entries() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_storage = temp_dir.path().join("workspaceStorage");
+        let workspace_dir = workspace_storage.join("abc123");
+        let workspace_file = temp_dir.path().join("dev.code-workspace");
+
+        fs::create_dir_all(&workspace_dir).unwrap();
+        fs::write(&workspace_file, "{}\n").unwrap();
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            format!(
+                r#"{{"workspace":"{}"}}"#,
+                url::Url::from_file_path(&workspace_file).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let (projects, warnings) = list(workspace_storage).unwrap();
+
+        assert!(warnings.entries.is_empty());
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].folder_id, "abc123");
+        assert_eq!(projects[0].path, workspace_file);
+        assert!(projects[0].remote.is_none());
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -561,7 +561,7 @@ mod tests {
 
     #[test]
     fn test_sort_by_chats_places_unknown_last() {
-        let mut projects = vec![
+        let mut projects = [
             Project {
                 folder_id: "a".to_string(),
                 path: PathBuf::from("/a"),

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -19,6 +19,7 @@ use url::Url;
 
 use super::utils;
 use crate::config;
+use crate::cursor::sqlite_value::query_optional_utf8_string_like_value;
 use crate::cursor::{folder_id, storage, workspace};
 
 /// Execute the rename command
@@ -483,15 +484,13 @@ fn update_composer_data(conn: &Connection, data: &str) -> Result<()> {
 }
 
 fn fetch_composer_data(conn: &Connection) -> Result<Option<String>> {
-    match conn.query_row(
-        "SELECT value FROM ItemTable WHERE key = 'composer.composerData'",
-        [],
-        |row| row.get::<_, String>(0),
-    ) {
-        Ok(value) => Ok(Some(value)),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-        Err(e) => Err(e).context("Failed to query composer.composerData"),
-    }
+    query_optional_utf8_string_like_value(
+        conn,
+        "SELECT value FROM ItemTable WHERE key = ?1",
+        "composer.composerData",
+        "value",
+    )
+    .context("Failed to query composer.composerData")
 }
 
 fn normalize_composer_data(
@@ -850,10 +849,12 @@ fn copy_or_move(src: &Path, dst: &Path, copy_mode: bool, dry_run: bool) -> Resul
     let options = CopyOptions::new().copy_inside(true).skip_exist(merge);
 
     let action = if copy_mode { "copy" } else { "move" };
-    let result = if copy_mode {
-        dir::copy(src, dst, &options).map(|_| ())
+    let result: Result<()> = if copy_mode {
+        dir::copy(src, dst, &options)
+            .map(|_| ())
+            .map_err(Into::into)
     } else {
-        dir::move_dir(src, dst, &options).map(|_| ())
+        move_or_merge_dir(src, dst, merge)
     };
 
     result.with_context(|| {
@@ -864,6 +865,360 @@ fn copy_or_move(src: &Path, dst: &Path, copy_mode: bool, dry_run: bool) -> Resul
             dst.display()
         )
     })
+}
+
+fn move_or_merge_dir(src: &Path, dst: &Path, merge: bool) -> Result<()> {
+    ensure_real_directory(src, "Source")?;
+
+    if merge {
+        ensure_real_directory(dst, "Target")?;
+        return move_dir_merge(src, dst);
+    }
+
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
+            move_dir_cross_device(src, dst)
+        }
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "Failed to atomically rename {} to {}",
+                src.display(),
+                dst.display()
+            )
+        }),
+    }
+}
+
+fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to access {label} directory: {}", path.display()))?;
+    let file_type = metadata.file_type();
+
+    if file_type.is_symlink() {
+        bail!("{label} must not be a symlink: {}", path.display())
+    }
+
+    if file_type.is_dir() {
+        return Ok(());
+    }
+
+    bail!("{label} is not a directory: {}", path.display())
+}
+
+fn move_dir_cross_device(src: &Path, dst: &Path) -> Result<()> {
+    move_dir_cross_device_with(src, dst, &mut |_, _| Ok(()))
+}
+
+fn move_dir_cross_device_with<F>(src: &Path, dst: &Path, before_copy: &mut F) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> Result<()>,
+{
+    move_dir_cross_device_with_hooks(src, dst, before_copy, &mut |_| Ok(()))
+}
+
+fn move_dir_cross_device_with_hooks<F, R>(
+    src: &Path,
+    dst: &Path,
+    before_copy: &mut F,
+    before_remove: &mut R,
+) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> Result<()>,
+    R: FnMut(&Path) -> Result<()>,
+{
+    let parent = dst
+        .parent()
+        .context("Destination path has no parent directory")?;
+    let staging_dir = tempfile::Builder::new()
+        .prefix(".cursor-helper-move-")
+        .tempdir_in(parent)
+        .with_context(|| {
+            format!(
+                "Failed to create staging directory under {}",
+                parent.display()
+            )
+        })?;
+    let staging_path = staging_dir.path().join("payload");
+
+    copy_path_no_follow_symlinks_with(src, &staging_path, before_copy)?;
+    if let Err(err) = remove_path_no_follow_symlinks_with(src, before_remove) {
+        restore_directory_from_staging(&staging_path, src).with_context(|| {
+            format!(
+                "Failed to restore source after removal error while moving {} to {}",
+                src.display(),
+                dst.display()
+            )
+        })?;
+        return Err(err).with_context(|| {
+            format!(
+                "Failed to remove original directory while moving {} to {}",
+                src.display(),
+                dst.display()
+            )
+        });
+    }
+
+    if let Err(err) = fs::rename(&staging_path, dst) {
+        restore_directory_from_staging(&staging_path, src).with_context(|| {
+            format!(
+                "Failed to restore source after finalize error while moving {} to {}",
+                src.display(),
+                dst.display()
+            )
+        })?;
+        return Err(err).with_context(|| {
+            format!(
+                "Failed to finalize staged move from {} to {}",
+                src.display(),
+                dst.display()
+            )
+        });
+    }
+
+    Ok(())
+}
+
+fn move_dir_merge(src: &Path, dst: &Path) -> Result<()> {
+    move_dir_merge_with(src, dst, &mut |_, _| Ok(()))
+}
+
+fn move_dir_merge_with<F>(src: &Path, dst: &Path, before_copy: &mut F) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> Result<()>,
+{
+    let mut moved_entries = Vec::new();
+    copy_dir_contents_no_follow_symlinks_with(src, dst, &mut moved_entries, before_copy)?;
+
+    moved_entries.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    for moved_entry in moved_entries {
+        remove_path_no_follow_symlinks(&moved_entry)?;
+    }
+
+    prune_empty_dirs(src)
+}
+
+fn copy_dir_contents_no_follow_symlinks_with<F>(
+    src: &Path,
+    dst: &Path,
+    moved_entries: &mut Vec<PathBuf>,
+    before_copy: &mut F,
+) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> Result<()>,
+{
+    let entries = fs::read_dir(src)
+        .with_context(|| format!("Failed to read directory: {}", src.display()))?;
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("Failed to read entry in {}", src.display()))?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let src_type = fs::symlink_metadata(&src_path)
+            .with_context(|| format!("Failed to inspect {}", src_path.display()))?
+            .file_type();
+
+        if path_exists_no_follow(&dst_path) {
+            let dst_type = fs::symlink_metadata(&dst_path)
+                .with_context(|| format!("Failed to inspect {}", dst_path.display()))?
+                .file_type();
+            if src_type.is_dir() && dst_type.is_dir() {
+                copy_dir_contents_no_follow_symlinks_with(
+                    &src_path,
+                    &dst_path,
+                    moved_entries,
+                    before_copy,
+                )?;
+            }
+            continue;
+        }
+
+        copy_path_no_follow_symlinks_with(&src_path, &dst_path, before_copy)?;
+        moved_entries.push(src_path);
+    }
+
+    Ok(())
+}
+
+fn copy_path_no_follow_symlinks_with<F>(src: &Path, dst: &Path, before_copy: &mut F) -> Result<()>
+where
+    F: FnMut(&Path, &Path) -> Result<()>,
+{
+    before_copy(src, dst)?;
+
+    let metadata = fs::symlink_metadata(src)
+        .with_context(|| format!("Failed to inspect {}", src.display()))?;
+    let file_type = metadata.file_type();
+
+    if file_type.is_dir() {
+        fs::create_dir(dst)
+            .with_context(|| format!("Failed to create directory: {}", dst.display()))?;
+
+        let entries = fs::read_dir(src)
+            .with_context(|| format!("Failed to read directory: {}", src.display()))?;
+        for entry in entries {
+            let entry =
+                entry.with_context(|| format!("Failed to read entry in {}", src.display()))?;
+            let child_src = entry.path();
+            let child_dst = dst.join(entry.file_name());
+            copy_path_no_follow_symlinks_with(&child_src, &child_dst, before_copy)?;
+        }
+
+        fs::set_permissions(dst, metadata.permissions())
+            .with_context(|| format!("Failed to set permissions on {}", dst.display()))?;
+        return Ok(());
+    }
+
+    if file_type.is_file() {
+        fs::copy(src, dst)
+            .with_context(|| format!("Failed to copy {} to {}", src.display(), dst.display()))?;
+        fs::set_permissions(dst, metadata.permissions())
+            .with_context(|| format!("Failed to set permissions on {}", dst.display()))?;
+        return Ok(());
+    }
+
+    if file_type.is_symlink() {
+        let target = fs::read_link(src)
+            .with_context(|| format!("Failed to read symlink target for {}", src.display()))?;
+        let is_dir = symlink_targets_directory(src, &file_type);
+        create_symlink_at(dst, &target, is_dir).with_context(|| {
+            format!(
+                "Failed to recreate symlink {} -> {}",
+                dst.display(),
+                target.display()
+            )
+        })?;
+        return Ok(());
+    }
+
+    bail!("Unsupported filesystem entry: {}", src.display())
+}
+
+fn remove_path_no_follow_symlinks(path: &Path) -> Result<()> {
+    remove_path_no_follow_symlinks_with(path, &mut |_| Ok(()))
+}
+
+fn remove_path_no_follow_symlinks_with<F>(path: &Path, before_remove: &mut F) -> Result<()>
+where
+    F: FnMut(&Path) -> Result<()>,
+{
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect {}", path.display()))?;
+    let file_type = metadata.file_type();
+    before_remove(path)?;
+
+    if file_type.is_dir() {
+        let entries = fs::read_dir(path)
+            .with_context(|| format!("Failed to read directory: {}", path.display()))?;
+        for entry in entries {
+            let entry =
+                entry.with_context(|| format!("Failed to read entry in {}", path.display()))?;
+            remove_path_no_follow_symlinks_with(&entry.path(), before_remove)?;
+        }
+        fs::remove_dir(path)
+            .with_context(|| format!("Failed to remove directory: {}", path.display()))?;
+        return Ok(());
+    }
+
+    fs::remove_file(path).with_context(|| format!("Failed to remove file: {}", path.display()))?;
+    Ok(())
+}
+
+fn restore_directory_from_staging(staging_path: &Path, src: &Path) -> Result<()> {
+    let mut noop = |_: &Path, _: &Path| Ok(());
+
+    if path_exists_no_follow(src) {
+        ensure_real_directory(src, "Source")?;
+        let mut restored_entries = Vec::new();
+        copy_dir_contents_no_follow_symlinks_with(
+            staging_path,
+            src,
+            &mut restored_entries,
+            &mut noop,
+        )?;
+    } else {
+        copy_path_no_follow_symlinks_with(staging_path, src, &mut noop)?;
+    }
+
+    Ok(())
+}
+
+fn prune_empty_dirs(path: &Path) -> Result<()> {
+    if !path_exists_no_follow(path) {
+        return Ok(());
+    }
+
+    if !fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect {}", path.display()))?
+        .file_type()
+        .is_dir()
+    {
+        return Ok(());
+    }
+
+    let children: Vec<PathBuf> = fs::read_dir(path)
+        .with_context(|| format!("Failed to read directory: {}", path.display()))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::result::Result<_, _>>()
+        .with_context(|| format!("Failed to enumerate directory: {}", path.display()))?;
+
+    for child in &children {
+        if fs::symlink_metadata(child)
+            .with_context(|| format!("Failed to inspect {}", child.display()))?
+            .file_type()
+            .is_dir()
+        {
+            prune_empty_dirs(child)?;
+        }
+    }
+
+    if fs::read_dir(path)
+        .with_context(|| format!("Failed to read directory: {}", path.display()))?
+        .next()
+        .is_none()
+    {
+        fs::remove_dir(path)
+            .with_context(|| format!("Failed to remove directory: {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn path_exists_no_follow(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok()
+}
+
+#[cfg(windows)]
+fn symlink_targets_directory(src: &Path, file_type: &fs::FileType) -> bool {
+    use std::os::windows::fs::FileTypeExt;
+
+    if file_type.is_symlink_dir() {
+        return true;
+    }
+    if file_type.is_symlink_file() {
+        return false;
+    }
+
+    fs::metadata(src).map(|meta| meta.is_dir()).unwrap_or(false)
+}
+
+#[cfg(not(windows))]
+fn symlink_targets_directory(src: &Path, _file_type: &fs::FileType) -> bool {
+    fs::metadata(src).map(|meta| meta.is_dir()).unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn create_symlink_at(path: &Path, target: &Path, _is_dir: bool) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, path)
+}
+
+#[cfg(windows)]
+fn create_symlink_at(path: &Path, target: &Path, is_dir: bool) -> std::io::Result<()> {
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, path)
+    } else {
+        std::os::windows::fs::symlink_file(target, path)
+    }
 }
 
 /// Convert a path to a file:// URI
@@ -891,6 +1246,9 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::{symlink, MetadataExt};
 
     #[test]
     fn test_clean_path_basic() {
@@ -937,6 +1295,195 @@ mod tests {
         let path = PathBuf::from("/home/user/my project");
         let uri = path_to_file_uri(&path).unwrap();
         assert_eq!(uri, "file:///home/user/my%20project");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_move_or_merge_dir_uses_atomic_rename_and_preserves_broken_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("app.py"), "print('ok')\n").unwrap();
+        symlink(Path::new("/missing/python3.9"), src.join("python")).unwrap();
+
+        let src_inode = fs::metadata(&src).unwrap().ino();
+        move_or_merge_dir(&src, &dst, false).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::metadata(&dst).unwrap().ino(), src_inode);
+        assert_eq!(
+            fs::read_to_string(dst.join("app.py")).unwrap(),
+            "print('ok')\n"
+        );
+        assert!(fs::symlink_metadata(dst.join("python"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_link(dst.join("python")).unwrap(),
+            PathBuf::from("/missing/python3.9")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_move_or_merge_dir_rejects_source_symlink_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let target = temp_dir.path().join("real-project");
+        let src = temp_dir.path().join("project-link");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("app.py"), "print('ok')\n").unwrap();
+        symlink(&target, &src).unwrap();
+
+        let err = move_or_merge_dir(&src, &dst, false).unwrap_err();
+
+        assert!(err.to_string().contains("must not be a symlink"));
+        assert!(src.exists());
+        assert!(!dst.exists());
+        assert_eq!(
+            fs::read_to_string(target.join("app.py")).unwrap(),
+            "print('ok')\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_move_dir_cross_device_preserves_broken_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("README.md"), "hello\n").unwrap();
+        symlink(Path::new("/missing/python3.9"), src.join("python")).unwrap();
+
+        move_dir_cross_device(&src, &dst).unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(
+            fs::read_to_string(dst.join("README.md")).unwrap(),
+            "hello\n"
+        );
+        assert!(fs::symlink_metadata(dst.join("python"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_link(dst.join("python")).unwrap(),
+            PathBuf::from("/missing/python3.9")
+        );
+    }
+
+    #[test]
+    fn test_move_dir_cross_device_failure_keeps_source_intact() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("one.txt"), "one\n").unwrap();
+        fs::write(src.join("two.txt"), "two\n").unwrap();
+
+        let mut seen_files = 0usize;
+        let err = move_dir_cross_device_with(&src, &dst, &mut |candidate, _| {
+            if fs::symlink_metadata(candidate)
+                .unwrap()
+                .file_type()
+                .is_file()
+            {
+                seen_files += 1;
+                if seen_files == 2 {
+                    bail!("injected copy failure");
+                }
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("injected copy failure"));
+        assert!(src.exists());
+        assert_eq!(fs::read_to_string(src.join("one.txt")).unwrap(), "one\n");
+        assert_eq!(fs::read_to_string(src.join("two.txt")).unwrap(), "two\n");
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_move_dir_cross_device_remove_failure_restores_source() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("one.txt"), "one\n").unwrap();
+        fs::write(src.join("two.txt"), "two\n").unwrap();
+
+        let mut removed_files = 0usize;
+        let err =
+            move_dir_cross_device_with_hooks(&src, &dst, &mut |_, _| Ok(()), &mut |candidate| {
+                if fs::symlink_metadata(candidate)
+                    .unwrap()
+                    .file_type()
+                    .is_file()
+                {
+                    removed_files += 1;
+                    if removed_files == 2 {
+                        bail!("injected remove failure");
+                    }
+                }
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(removed_files, 2);
+        assert!(!err.to_string().is_empty());
+        assert!(src.exists());
+        assert_eq!(fs::read_to_string(src.join("one.txt")).unwrap(), "one\n");
+        assert_eq!(fs::read_to_string(src.join("two.txt")).unwrap(), "two\n");
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_move_dir_merge_skips_conflicts_and_removes_copied_entries() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst = temp_dir.path().join("project-new");
+        fs::create_dir_all(src.join("subdir")).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(src.join("conflict.txt"), "from source\n").unwrap();
+        fs::write(src.join("subdir").join("moved.txt"), "moved\n").unwrap();
+        fs::write(dst.join("conflict.txt"), "from destination\n").unwrap();
+
+        move_dir_merge(&src, &dst).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dst.join("conflict.txt")).unwrap(),
+            "from destination\n"
+        );
+        assert_eq!(
+            fs::read_to_string(dst.join("subdir").join("moved.txt")).unwrap(),
+            "moved\n"
+        );
+        assert!(src.join("conflict.txt").exists());
+        assert!(!src.join("subdir").exists());
+        assert!(src.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_move_dir_merge_rejects_target_symlink_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("project-old");
+        let dst_target = temp_dir.path().join("real-target");
+        let dst = temp_dir.path().join("project-link");
+        fs::create_dir(&src).unwrap();
+        fs::create_dir(&dst_target).unwrap();
+        fs::write(src.join("moved.txt"), "moved\n").unwrap();
+        symlink(&dst_target, &dst).unwrap();
+
+        let err = move_or_merge_dir(&src, &dst, true).unwrap_err();
+
+        assert!(err.to_string().contains("must not be a symlink"));
+        assert!(src.join("moved.txt").exists());
+        assert!(fs::read_dir(&dst_target).unwrap().next().is_none());
     }
 
     #[cfg(windows)]

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -7,8 +7,9 @@
 //! - Terminal info
 
 use anyhow::{bail, Context, Result};
-use fs_extra::dir::{self, CopyOptions};
+use fs_extra::dir::{self, CopyOptions as FsCopyOptions};
 use owo_colors::OwoColorize;
+use parcopy::{copy_dir as parcopy_copy_dir, CopyOptions as ParcopyCopyOptions, OnConflict};
 use rusqlite::Connection;
 use std::fs;
 use std::io::{self, Write};
@@ -846,7 +847,7 @@ fn copy_or_move(src: &Path, dst: &Path, copy_mode: bool, dry_run: bool) -> Resul
         return Ok(());
     }
 
-    let options = CopyOptions::new().copy_inside(true).skip_exist(merge);
+    let options = FsCopyOptions::new().copy_inside(true).skip_exist(merge);
 
     let action = if copy_mode { "copy" } else { "move" };
     let result: Result<()> = if copy_mode {
@@ -925,20 +926,20 @@ fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
 }
 
 fn move_dir_cross_device(src: &Path, dst: &Path) -> Result<()> {
-    move_dir_cross_device_with(src, dst, &mut |_, _| Ok(()))
+    move_dir_cross_device_with_copy(src, dst, &mut copy_dir_to_staging)
 }
 
-fn move_dir_cross_device_with<F>(src: &Path, dst: &Path, before_copy: &mut F) -> Result<()>
+fn move_dir_cross_device_with_copy<F>(src: &Path, dst: &Path, copy_to_staging: &mut F) -> Result<()>
 where
     F: FnMut(&Path, &Path) -> Result<()>,
 {
-    move_dir_cross_device_with_hooks(src, dst, before_copy, &mut |_| Ok(()))
+    move_dir_cross_device_with_hooks(src, dst, copy_to_staging, &mut |_| Ok(()))
 }
 
 fn move_dir_cross_device_with_hooks<F, R>(
     src: &Path,
     dst: &Path,
-    before_copy: &mut F,
+    copy_to_staging: &mut F,
     before_remove: &mut R,
 ) -> Result<()>
 where
@@ -959,7 +960,7 @@ where
         })?;
     let staging_path = staging_dir.path().join("payload");
 
-    copy_path_no_follow_symlinks_with(src, &staging_path, before_copy)?;
+    copy_to_staging(src, &staging_path)?;
     if let Err(err) = remove_path_no_follow_symlinks_with(src, before_remove) {
         restore_directory_from_staging(&staging_path, src).with_context(|| {
             format!(
@@ -995,6 +996,19 @@ where
     }
 
     Ok(())
+}
+
+fn copy_dir_to_staging(src: &Path, staging_path: &Path) -> Result<()> {
+    let options = ParcopyCopyOptions::default().with_on_conflict(OnConflict::Error);
+    parcopy_copy_dir(src, staging_path, &options)
+        .map(|_| ())
+        .with_context(|| {
+            format!(
+                "Failed to stage copy {} to {}",
+                src.display(),
+                staging_path.display()
+            )
+        })
 }
 
 fn move_dir_merge(src: &Path, dst: &Path) -> Result<()> {
@@ -1416,21 +1430,9 @@ mod tests {
         fs::write(src.join("one.txt"), "one\n").unwrap();
         fs::write(src.join("two.txt"), "two\n").unwrap();
 
-        let mut seen_files = 0usize;
-        let err = move_dir_cross_device_with(&src, &dst, &mut |candidate, _| {
-            if fs::symlink_metadata(candidate)
-                .unwrap()
-                .file_type()
-                .is_file()
-            {
-                seen_files += 1;
-                if seen_files == 2 {
-                    bail!("injected copy failure");
-                }
-            }
-            Ok(())
-        })
-        .unwrap_err();
+        let err =
+            move_dir_cross_device_with_copy(&src, &dst, &mut |_, _| bail!("injected copy failure"))
+                .unwrap_err();
 
         assert!(err.to_string().contains("injected copy failure"));
         assert!(src.exists());
@@ -1449,8 +1451,11 @@ mod tests {
         fs::write(src.join("two.txt"), "two\n").unwrap();
 
         let mut removed_files = 0usize;
-        let err =
-            move_dir_cross_device_with_hooks(&src, &dst, &mut |_, _| Ok(()), &mut |candidate| {
+        let err = move_dir_cross_device_with_hooks(
+            &src,
+            &dst,
+            &mut copy_dir_to_staging,
+            &mut |candidate| {
                 if fs::symlink_metadata(candidate)
                     .unwrap()
                     .file_type()
@@ -1462,8 +1467,9 @@ mod tests {
                     }
                 }
                 Ok(())
-            })
-            .unwrap_err();
+            },
+        )
+        .unwrap_err();
 
         assert_eq!(removed_files, 2);
         assert!(!err.to_string().is_empty());

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -877,9 +877,7 @@ fn move_or_merge_dir(src: &Path, dst: &Path, merge: bool) -> Result<()> {
 
     match fs::rename(src, dst) {
         Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
-            move_dir_cross_device(src, dst)
-        }
+        Err(err) if is_cross_device_error(&err) => move_dir_cross_device(src, dst),
         Err(err) => Err(err).with_context(|| {
             format!(
                 "Failed to atomically rename {} to {}",
@@ -887,6 +885,26 @@ fn move_or_merge_dir(src: &Path, dst: &Path, merge: bool) -> Result<()> {
                 dst.display()
             )
         }),
+    }
+}
+
+fn is_cross_device_error(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        // EXDEV: cross-device link.
+        err.raw_os_error() == Some(18)
+    }
+
+    #[cfg(windows)]
+    {
+        // ERROR_NOT_SAME_DEVICE.
+        err.raw_os_error() == Some(17)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = err;
+        false
     }
 }
 
@@ -1295,6 +1313,20 @@ mod tests {
         let path = PathBuf::from("/home/user/my project");
         let uri = path_to_file_uri(&path).unwrap();
         assert_eq!(uri, "file:///home/user/my%20project");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_is_cross_device_error_unix() {
+        assert!(is_cross_device_error(&io::Error::from_raw_os_error(18)));
+        assert!(!is_cross_device_error(&io::Error::from_raw_os_error(2)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_is_cross_device_error_windows() {
+        assert!(is_cross_device_error(&io::Error::from_raw_os_error(17)));
+        assert!(!is_cross_device_error(&io::Error::from_raw_os_error(2)));
     }
 
     #[cfg(unix)]

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -2,8 +2,11 @@
 
 use anyhow::{Context, Result};
 use fs_extra::dir::{self, CopyOptions};
+use percent_encoding::percent_decode_str;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use crate::cursor::workspace;
 
 /// Format bytes as human-readable size
 pub fn format_size(bytes: u64) -> String {
@@ -102,17 +105,9 @@ pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathB
                 continue;
             }
 
-            let workspace_json = entry.path().join("workspace.json");
-            if !workspace_json.exists() {
-                continue;
-            }
-
-            let content = fs::read_to_string(&workspace_json)?;
-            let ws: serde_json::Value = serde_json::from_str(&content)?;
-
-            if let Some(folder) = ws.get("folder").and_then(|v| v.as_str()) {
-                let folder_normalized = normalize_uri_for_comparison(folder);
-                if folder_normalized == project_uri_normalized {
+            if let Some(target_uri) = workspace::read_workspace_target_uri(&entry.path())? {
+                let target_normalized = normalize_uri_for_comparison(&target_uri);
+                if target_normalized == project_uri_normalized {
                     return Ok(Some(entry.path()));
                 }
             }
@@ -129,17 +124,9 @@ pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathB
             continue;
         }
 
-        let workspace_json = entry.path().join("workspace.json");
-        if !workspace_json.exists() {
-            continue;
-        }
-
-        let content = fs::read_to_string(&workspace_json)?;
-        let ws: serde_json::Value = serde_json::from_str(&content)?;
-
-        if let Some(folder) = ws.get("folder").and_then(|v| v.as_str()) {
+        if let Some(target_uri) = workspace::read_workspace_target_uri(&entry.path())? {
             // Check if this is a remote URL and extract the path
-            if let Ok(url) = url::Url::parse(folder) {
+            if let Ok(url) = url::Url::parse(&target_uri) {
                 if url.scheme() == "vscode-remote" {
                     // Extract path from remote URL and compare
                     let remote_path = url.path().trim_end_matches('/');
@@ -172,12 +159,60 @@ pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathB
 ///
 /// This normalization is safe to apply on all platforms.
 fn normalize_uri_for_comparison(uri: &str) -> String {
-    uri.trim_end_matches('/').to_lowercase().replace("%3a", ":")
+    let trimmed = uri.trim_end_matches('/');
+    let Some((scheme, authority, path)) = split_uri(trimmed) else {
+        return normalize_workspace_path(trimmed);
+    };
+
+    let path = normalize_workspace_path(&path);
+
+    if authority.is_empty() {
+        format!("{}://{}", scheme.to_ascii_lowercase(), path)
+    } else {
+        format!("{}://{}{}", scheme.to_ascii_lowercase(), authority, path)
+    }
+}
+
+fn normalize_workspace_path(path: &str) -> String {
+    let trimmed = path
+        .trim_end_matches('/')
+        .replace("%3A", ":")
+        .replace("%3a", ":");
+    let decoded = percent_decode_str(&trimmed).decode_utf8_lossy();
+    normalize_drive_letter(&decoded)
+}
+
+fn split_uri(uri: &str) -> Option<(&str, String, String)> {
+    let (scheme, rest) = uri.split_once("://")?;
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, ""),
+    };
+
+    Some((scheme, authority.to_string(), path.to_string()))
+}
+
+fn normalize_drive_letter(path: &str) -> String {
+    let mut chars: Vec<char> = path.chars().collect();
+
+    let drive_index = match chars.as_slice() {
+        ['/', drive, ':', '/', ..] if drive.is_ascii_alphabetic() => Some(1),
+        [drive, ':', '/', ..] if drive.is_ascii_alphabetic() => Some(0),
+        _ => None,
+    };
+
+    if let Some(index) = drive_index {
+        chars[index] = chars[index].to_ascii_lowercase();
+        chars.into_iter().collect()
+    } else {
+        path.to_string()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_format_size() {
@@ -235,9 +270,21 @@ mod tests {
 
     #[test]
     fn test_normalize_uri_unix_paths() {
-        // Unix paths should also work (lowercasing is harmless)
+        // Unix paths should preserve case
         let result = normalize_uri_for_comparison("file:///Users/me/project/");
-        assert_eq!(result, "file:///users/me/project");
+        assert_eq!(result, "file:///Users/me/project");
+    }
+
+    #[test]
+    fn test_normalize_uri_preserves_case_for_posix_paths() {
+        assert_eq!(
+            normalize_uri_for_comparison("file:///tmp/Project"),
+            "file:///tmp/Project"
+        );
+        assert_ne!(
+            normalize_uri_for_comparison("file:///tmp/Project"),
+            normalize_uri_for_comparison("file:///tmp/project")
+        );
     }
 
     #[test]
@@ -246,5 +293,40 @@ mod tests {
         let result = find_workspace_dir(Path::new("/nonexistent/path/that/does/not/exist"));
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_workspace_dir_matches_multi_root_workspace_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let original = std::env::var_os("XDG_CONFIG_HOME");
+        let workspace_storage = temp_dir
+            .path()
+            .join("Cursor")
+            .join("User")
+            .join("workspaceStorage");
+        let workspace_dir = workspace_storage.join("abc123");
+        let workspace_file = temp_dir.path().join("project.code-workspace");
+
+        fs::create_dir_all(&workspace_dir).unwrap();
+        fs::write(&workspace_file, "{}\n").unwrap();
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            format!(
+                r#"{{"workspace":"{}"}}"#,
+                url::Url::from_file_path(&workspace_file).unwrap()
+            ),
+        )
+        .unwrap();
+
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        let result = find_workspace_dir(&workspace_file);
+
+        if let Some(value) = original {
+            std::env::set_var("XDG_CONFIG_HOME", value);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        assert_eq!(result.unwrap(), Some(workspace_dir));
     }
 }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -87,7 +87,13 @@ pub fn calculate_dir_size(path: &Path) -> Result<u64> {
 /// - Remote: if path doesn't exist locally, searches vscode-remote:// URLs for matching path component
 pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathBuf>> {
     let workspace_storage_dir = crate::config::workspace_storage_dir()?;
+    find_workspace_dir_in(&workspace_storage_dir, project_path)
+}
 
+fn find_workspace_dir_in(
+    workspace_storage_dir: &Path,
+    project_path: &Path,
+) -> Result<Option<std::path::PathBuf>> {
     if !workspace_storage_dir.exists() {
         return Ok(None);
     }
@@ -100,7 +106,7 @@ pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathB
         let project_uri_normalized = normalize_uri_for_comparison(&project_uri);
 
         // Scan workspace storage for matching local project
-        for entry in fs::read_dir(&workspace_storage_dir)?.flatten() {
+        for entry in fs::read_dir(workspace_storage_dir)?.flatten() {
             if !entry.file_type()?.is_dir() {
                 continue;
             }
@@ -119,7 +125,7 @@ pub fn find_workspace_dir(project_path: &Path) -> Result<Option<std::path::PathB
     let search_path = project_path.to_string_lossy();
     let search_path_normalized = search_path.trim_end_matches('/');
 
-    for entry in fs::read_dir(&workspace_storage_dir)?.flatten() {
+    for entry in fs::read_dir(workspace_storage_dir)?.flatten() {
         if !entry.file_type()?.is_dir() {
             continue;
         }
@@ -298,12 +304,7 @@ mod tests {
     #[test]
     fn test_find_workspace_dir_matches_multi_root_workspace_file() {
         let temp_dir = TempDir::new().unwrap();
-        let original = std::env::var_os("XDG_CONFIG_HOME");
-        let workspace_storage = temp_dir
-            .path()
-            .join("Cursor")
-            .join("User")
-            .join("workspaceStorage");
+        let workspace_storage = temp_dir.path().join("workspaceStorage");
         let workspace_dir = workspace_storage.join("abc123");
         let workspace_file = temp_dir.path().join("project.code-workspace");
 
@@ -318,14 +319,7 @@ mod tests {
         )
         .unwrap();
 
-        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
-        let result = find_workspace_dir(&workspace_file);
-
-        if let Some(value) = original {
-            std::env::set_var("XDG_CONFIG_HOME", value);
-        } else {
-            std::env::remove_var("XDG_CONFIG_HOME");
-        }
+        let result = find_workspace_dir_in(&workspace_storage, &workspace_file);
 
         assert_eq!(result.unwrap(), Some(workspace_dir));
     }

--- a/src/cursor/chat_sessions.rs
+++ b/src/cursor/chat_sessions.rs
@@ -2,11 +2,13 @@
 
 use anyhow::{Context, Result};
 use percent_encoding::percent_decode_str;
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use crate::cursor::sqlite_value::query_optional_utf8_string_like_value;
 
 const GLOBAL_HEADERS_KEY: &str = "composer.composerHeaders";
 const LOCAL_COMPOSER_DATA_KEY: &str = "composer.composerData";
@@ -246,22 +248,22 @@ fn load_legacy_local_sessions(
 }
 
 fn query_item_table_value(conn: &Connection, key: &str) -> Result<Option<String>> {
-    conn.query_row(
+    query_optional_utf8_string_like_value(
+        conn,
         "SELECT value FROM ItemTable WHERE key = ?1",
-        rusqlite::params![key],
-        |row| row.get::<_, String>(0),
+        key,
+        "value",
     )
-    .optional()
     .with_context(|| format!("Failed to query ItemTable for key: {}", key))
 }
 
 fn query_cursor_disk_value(conn: &Connection, key: &str) -> Result<Option<String>> {
-    conn.query_row(
+    query_optional_utf8_string_like_value(
+        conn,
         "SELECT value FROM cursorDiskKV WHERE key = ?1",
-        rusqlite::params![key],
-        |row| row.get::<_, String>(0),
+        key,
+        "value",
     )
-    .optional()
     .with_context(|| format!("Failed to query cursorDiskKV for key: {}", key))
 }
 

--- a/src/cursor/chat_sessions.rs
+++ b/src/cursor/chat_sessions.rs
@@ -5,10 +5,10 @@ use percent_encoding::percent_decode_str;
 use rusqlite::Connection;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::cursor::sqlite_value::query_optional_utf8_string_like_value;
+use crate::cursor::workspace;
 
 const GLOBAL_HEADERS_KEY: &str = "composer.composerHeaders";
 const LOCAL_COMPOSER_DATA_KEY: &str = "composer.composerData";
@@ -45,16 +45,9 @@ impl WorkspaceIdentity {
             };
         }
 
-        let folder_uri = fs::read_to_string(&workspace_json_path)
+        let folder_uri = workspace::read_workspace_target_uri(workspace_dir)
             .ok()
-            .and_then(|content| serde_json::from_str::<Value>(&content).ok())
-            .and_then(|workspace| {
-                workspace
-                    .get("folder")
-                    .and_then(|value| value.as_str())
-                    .or_else(|| workspace.get("workspace").and_then(|value| value.as_str()))
-                    .map(|value| value.to_string())
-            });
+            .flatten();
 
         let folder_uri_normalized = folder_uri.as_deref().map(normalize_uri_for_comparison);
         let workspace_path_normalized = folder_uri.as_deref().and_then(extract_workspace_path);

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod chat_sessions;
 pub mod folder_id;
+pub mod sqlite_value;
 pub mod storage;
 pub mod workspace;
 

--- a/src/cursor/sqlite_value.rs
+++ b/src/cursor/sqlite_value.rs
@@ -1,0 +1,258 @@
+//! Shared SQLite value helpers for Cursor-managed databases.
+
+use rusqlite::types::ValueRef;
+use rusqlite::{params, Connection, OptionalExtension, Row};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Utf8SqlValue {
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+impl Utf8SqlValue {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Text(value) => value,
+            Self::Blob(bytes) => {
+                std::str::from_utf8(bytes).expect("Utf8SqlValue::Blob must contain valid UTF-8")
+            }
+        }
+    }
+
+    pub fn from_row(row: &Row<'_>, idx: usize) -> rusqlite::Result<Option<Self>> {
+        match row.get_ref(idx)? {
+            ValueRef::Null => Ok(None),
+            ValueRef::Text(bytes) => Ok(Some(Self::Text(std::str::from_utf8(bytes)?.to_string()))),
+            ValueRef::Blob(bytes) => match std::str::from_utf8(bytes) {
+                Ok(_) => Ok(Some(Self::Blob(bytes.to_vec()))),
+                Err(_) => Ok(None),
+            },
+            ValueRef::Integer(_) | ValueRef::Real(_) => Ok(None),
+        }
+    }
+
+    pub fn write_back(
+        &self,
+        conn: &Connection,
+        query: &str,
+        rowid: i64,
+    ) -> rusqlite::Result<usize> {
+        Ok(match self {
+            Self::Text(value) => conn.execute(query, params![value, rowid])?,
+            Self::Blob(bytes) => conn.execute(query, params![bytes, rowid])?,
+        })
+    }
+}
+
+pub fn query_optional_utf8_value(
+    conn: &Connection,
+    query: &str,
+    key: &str,
+) -> rusqlite::Result<Option<String>> {
+    let text_result = conn
+        .query_row(query, rusqlite::params![key], |row| {
+            Utf8SqlValue::from_row(row, 0)
+        })
+        .optional()?;
+    if let Some(value) = text_result {
+        return Ok(value.map(|value| value.as_str().to_string()));
+    }
+
+    conn.query_row(query, rusqlite::params![key.as_bytes()], |row| {
+        Utf8SqlValue::from_row(row, 0)
+    })
+    .optional()
+    .map(|value| value.flatten().map(|value| value.as_str().to_string()))
+}
+
+pub fn query_optional_utf8_string_like_value(
+    conn: &Connection,
+    query: &str,
+    key: &str,
+    column_name: &str,
+) -> rusqlite::Result<Option<String>> {
+    let strict_reader = |row: &Row<'_>| {
+        let idx = 0;
+        let value = row.get_ref(idx)?;
+
+        match value {
+            ValueRef::Null => Ok(None),
+            ValueRef::Text(bytes) => Ok(Some(std::str::from_utf8(bytes)?.to_string())),
+            ValueRef::Blob(bytes) => Ok(Some(std::str::from_utf8(bytes)?.to_string())),
+            ValueRef::Integer(_) | ValueRef::Real(_) => Err(rusqlite::Error::InvalidColumnType(
+                idx,
+                column_name.to_string(),
+                value.data_type(),
+            )),
+        }
+    };
+
+    let text_result = conn
+        .query_row(query, rusqlite::params![key], strict_reader)
+        .optional()?;
+    if let Some(value) = text_result {
+        return Ok(value);
+    }
+
+    conn.query_row(query, rusqlite::params![key.as_bytes()], strict_reader)
+        .optional()
+        .map(|value| value.flatten())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn reads_utf8_blob_values() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (value BLOB)", []).unwrap();
+        conn.execute(
+            "INSERT INTO data(value) VALUES (?1)",
+            [Vec::from("file:///workspace".as_bytes())],
+        )
+        .unwrap();
+
+        let value = conn
+            .query_row("SELECT value FROM data", [], |row| {
+                Utf8SqlValue::from_row(row, 0)
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(value, Utf8SqlValue::Blob(b"file:///workspace".to_vec()));
+        assert_eq!(value.as_str(), "file:///workspace");
+    }
+
+    #[test]
+    fn skips_invalid_utf8_blob_values() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (value BLOB)", []).unwrap();
+        conn.execute("INSERT INTO data(value) VALUES (X'80')", [])
+            .unwrap();
+
+        let value = conn
+            .query_row("SELECT value FROM data", [], |row| {
+                Utf8SqlValue::from_row(row, 0)
+            })
+            .unwrap();
+
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn strict_reader_accepts_utf8_blob_values() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (key TEXT PRIMARY KEY, value BLOB)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO data(key, value) VALUES (?1, ?2)",
+            ("composer", Vec::from("file:///workspace".as_bytes())),
+        )
+        .unwrap();
+
+        let value = query_optional_utf8_string_like_value(
+            &conn,
+            "SELECT value FROM data WHERE key = ?1",
+            "composer",
+            "value",
+        )
+        .unwrap();
+
+        assert_eq!(value.as_deref(), Some("file:///workspace"));
+    }
+
+    #[test]
+    fn strict_reader_rejects_integer_values() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE data (key TEXT PRIMARY KEY, value INTEGER)",
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO data(key, value) VALUES (?1, 42)", ["composer"])
+            .unwrap();
+
+        let err = query_optional_utf8_string_like_value(
+            &conn,
+            "SELECT value FROM data WHERE key = ?1",
+            "composer",
+            "value",
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, rusqlite::Error::InvalidColumnType(..)));
+    }
+
+    #[test]
+    fn strict_reader_rejects_invalid_utf8_blob_values() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (key TEXT PRIMARY KEY, value BLOB)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO data(key, value) VALUES (?1, X'80')",
+            ["composer"],
+        )
+        .unwrap();
+
+        let err = query_optional_utf8_string_like_value(
+            &conn,
+            "SELECT value FROM data WHERE key = ?1",
+            "composer",
+            "value",
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, rusqlite::Error::Utf8Error(_)));
+    }
+
+    #[test]
+    fn permissive_reader_matches_blob_keys() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (key BLOB PRIMARY KEY, value BLOB)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO data(key, value) VALUES (?1, ?2)",
+            (
+                Vec::from("composerData:workspace".as_bytes()),
+                Vec::from("file:///workspace".as_bytes()),
+            ),
+        )
+        .unwrap();
+
+        let value = query_optional_utf8_value(
+            &conn,
+            "SELECT value FROM data WHERE key = ?1",
+            "composerData:workspace",
+        )
+        .unwrap();
+
+        assert_eq!(value.as_deref(), Some("file:///workspace"));
+    }
+
+    #[test]
+    fn strict_reader_matches_blob_keys() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE data (key BLOB PRIMARY KEY, value BLOB)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO data(key, value) VALUES (?1, ?2)",
+            (
+                Vec::from("composer".as_bytes()),
+                Vec::from("file:///workspace".as_bytes()),
+            ),
+        )
+        .unwrap();
+
+        let value = query_optional_utf8_string_like_value(
+            &conn,
+            "SELECT value FROM data WHERE key = ?1",
+            "composer",
+            "value",
+        )
+        .unwrap();
+
+        assert_eq!(value.as_deref(), Some("file:///workspace"));
+    }
+}

--- a/src/cursor/sqlite_value.rs
+++ b/src/cursor/sqlite_value.rs
@@ -6,16 +6,14 @@ use rusqlite::{params, Connection, OptionalExtension, Row};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Utf8SqlValue {
     Text(String),
-    Blob(Vec<u8>),
+    Blob(String),
 }
 
 impl Utf8SqlValue {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Text(value) => value,
-            Self::Blob(bytes) => {
-                std::str::from_utf8(bytes).expect("Utf8SqlValue::Blob must contain valid UTF-8")
-            }
+            Self::Blob(value) => value,
         }
     }
 
@@ -24,7 +22,7 @@ impl Utf8SqlValue {
             ValueRef::Null => Ok(None),
             ValueRef::Text(bytes) => Ok(Some(Self::Text(std::str::from_utf8(bytes)?.to_string()))),
             ValueRef::Blob(bytes) => match std::str::from_utf8(bytes) {
-                Ok(_) => Ok(Some(Self::Blob(bytes.to_vec()))),
+                Ok(value) => Ok(Some(Self::Blob(value.to_string()))),
                 Err(_) => Ok(None),
             },
             ValueRef::Integer(_) | ValueRef::Real(_) => Ok(None),
@@ -39,7 +37,7 @@ impl Utf8SqlValue {
     ) -> rusqlite::Result<usize> {
         Ok(match self {
             Self::Text(value) => conn.execute(query, params![value, rowid])?,
-            Self::Blob(bytes) => conn.execute(query, params![bytes, rowid])?,
+            Self::Blob(value) => conn.execute(query, params![value.as_bytes(), rowid])?,
         })
     }
 }
@@ -121,7 +119,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(value, Utf8SqlValue::Blob(b"file:///workspace".to_vec()));
+        assert_eq!(value, Utf8SqlValue::Blob("file:///workspace".to_string()));
         assert_eq!(value.as_str(), "file:///workspace");
     }
 

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use super::sqlite_value::Utf8SqlValue;
+
 /// Update workspace references in storage.json
 ///
 /// This updates:
@@ -96,7 +98,7 @@ pub fn update_global_state_db<P: AsRef<Path>>(
         return Ok(false);
     }
 
-    let conn = Connection::open(state_db)
+    let mut conn = Connection::open(state_db)
         .with_context(|| format!("Failed to open global state DB: {}", state_db.display()))?;
 
     let mut modified = false;
@@ -120,53 +122,93 @@ pub fn update_global_state_db<P: AsRef<Path>>(
         ("cursorDiskKV", "value"),
     ];
 
+    if dry_run {
+        for (table, column) in targets {
+            if !table_exists(&conn, table)? || !column_exists(&conn, table, column)? {
+                continue;
+            }
+
+            let query = format!("SELECT {column} FROM {table}");
+            let mut stmt = conn.prepare(&query)?;
+            let mut rows = stmt.query([])?;
+
+            while let Some(row) = rows.next()? {
+                let value = Utf8SqlValue::from_row(row, 0)?;
+
+                let Some(value) = value else {
+                    continue;
+                };
+
+                if !has_workspace_scoped_reference(value.as_str(), &normalized_replacements) {
+                    continue;
+                }
+
+                let normalized =
+                    normalize_text_replacements(value.as_str(), &normalized_replacements);
+                if normalized != value.as_str() {
+                    return Ok(true);
+                }
+            }
+        }
+
+        return Ok(false);
+    }
+
+    let tx = conn
+        .transaction()
+        .with_context(|| format!("Failed to start transaction for: {}", state_db.display()))?;
+
     for (table, column) in targets {
-        if !table_exists(&conn, table)? || !column_exists(&conn, table, column)? {
+        if !table_exists(&tx, table)? || !column_exists(&tx, table, column)? {
             continue;
         }
 
         let query = format!("SELECT rowid, {column} FROM {table}");
-        let mut stmt = conn.prepare(&query)?;
+        let mut stmt = tx.prepare(&query)?;
         let mut rows = stmt.query([])?;
-        let mut pending_updates: Vec<(i64, String)> = Vec::new();
+        let mut pending_updates: Vec<(i64, Utf8SqlValue)> = Vec::new();
 
         while let Some(row) = rows.next()? {
             let rowid: i64 = row.get(0)?;
-            let value: Option<String> = row.get(1)?;
+            let value = Utf8SqlValue::from_row(row, 1)?;
 
             let Some(value) = value else {
                 continue;
             };
 
-            if !has_workspace_scoped_reference(&value, &normalized_replacements) {
+            if !has_workspace_scoped_reference(value.as_str(), &normalized_replacements) {
                 continue;
             }
 
-            let normalized = normalize_text_replacements(&value, &normalized_replacements);
+            let normalized = normalize_text_replacements(value.as_str(), &normalized_replacements);
 
-            if normalized == value {
+            if normalized == value.as_str() {
                 continue;
             }
 
-            if dry_run {
-                modified = true;
-                continue;
-            }
-
+            let normalized = match value {
+                Utf8SqlValue::Text(_) => Utf8SqlValue::Text(normalized),
+                Utf8SqlValue::Blob(_) => Utf8SqlValue::Blob(normalized.into_bytes()),
+            };
             pending_updates.push((rowid, normalized));
         }
 
         for (rowid, normalized) in pending_updates {
-            conn.execute(
-                &format!("UPDATE {table} SET {column} = ?1 WHERE rowid = ?2"),
-                params![normalized, rowid],
-            )
-            .with_context(|| {
-                format!("Failed to update {table}.{column} for row {rowid} in global state DB")
-            })?;
+            normalized
+                .write_back(
+                    &tx,
+                    &format!("UPDATE {table} SET {column} = ?1 WHERE rowid = ?2"),
+                    rowid,
+                )
+                .with_context(|| {
+                    format!("Failed to update {table}.{column} for row {rowid} in global state DB")
+                })?;
             modified = true;
         }
     }
+
+    tx.commit()
+        .context("Failed to commit global state DB update")?;
 
     Ok(modified)
 }
@@ -356,6 +398,7 @@ impl StorageJson {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cursor::sqlite_value::Utf8SqlValue;
     use std::io::Write;
     use tempfile::NamedTempFile;
     use tempfile::TempDir;
@@ -690,5 +733,131 @@ mod tests {
             r#"{"active":"file:///home/user/project-copy","other":"file:///home/user/projects/foo","cache":"hash-new"}"#
         );
         assert!(!row_value.contains("project-copy-copy"));
+    }
+
+    #[test]
+    fn test_update_global_state_db_updates_utf8_blob_values_without_changing_type() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-blob.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key BLOB PRIMARY KEY, value BLOB)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, ?2)",
+            (
+                "workspace.key.file:///old/path",
+                Vec::from("meta:file:///old/path/hash-old".as_bytes()),
+            ),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO cursorDiskKV(key, value) VALUES (?1, ?2)",
+            (
+                Vec::from("composer:hash-old".as_bytes()),
+                Vec::from("file:///old/path".as_bytes()),
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "/old/path",
+            "/new/path",
+            "file:///old/path",
+            "file:///new/path",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+
+        assert!(modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let item_value_type: String = conn
+            .query_row("SELECT typeof(value) FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+        let disk_key_type: String = conn
+            .query_row("SELECT typeof(key) FROM cursorDiskKV", [], |row| row.get(0))
+            .unwrap();
+        let disk_value_type: String = conn
+            .query_row("SELECT typeof(value) FROM cursorDiskKV", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let item_value = conn
+            .query_row("SELECT value FROM ItemTable", [], |row| {
+                Utf8SqlValue::from_row(row, 0)
+            })
+            .unwrap()
+            .unwrap();
+        let disk_key = conn
+            .query_row("SELECT key FROM cursorDiskKV", [], |row| {
+                Utf8SqlValue::from_row(row, 0)
+            })
+            .unwrap()
+            .unwrap();
+        let disk_value = conn
+            .query_row("SELECT value FROM cursorDiskKV", [], |row| {
+                Utf8SqlValue::from_row(row, 0)
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(item_value_type, "blob");
+        assert_eq!(disk_key_type, "blob");
+        assert_eq!(disk_value_type, "blob");
+        assert_eq!(item_value.as_str(), "meta:file:///new/path/hash-new");
+        assert_eq!(disk_key.as_str(), "composer:hash-new");
+        assert_eq!(disk_value.as_str(), "file:///new/path");
+    }
+
+    #[test]
+    fn test_update_global_state_db_skips_invalid_utf8_blob_values() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("state-invalid-blob.vscdb");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable(key, value) VALUES (?1, X'80')",
+            ["workspace.key.file:///other/path"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let modified = update_global_state_db(
+            &db_path,
+            "/old/path",
+            "/new/path",
+            "file:///old/path",
+            "file:///new/path",
+            "hash-old",
+            "hash-new",
+            false,
+        )
+        .unwrap();
+
+        assert!(!modified);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let raw: Vec<u8> = conn
+            .query_row("SELECT value FROM ItemTable", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(raw, vec![0x80]);
     }
 }

--- a/src/cursor/storage.rs
+++ b/src/cursor/storage.rs
@@ -188,7 +188,7 @@ pub fn update_global_state_db<P: AsRef<Path>>(
 
             let normalized = match value {
                 Utf8SqlValue::Text(_) => Utf8SqlValue::Text(normalized),
-                Utf8SqlValue::Blob(_) => Utf8SqlValue::Blob(normalized.into_bytes()),
+                Utf8SqlValue::Blob(_) => Utf8SqlValue::Blob(normalized),
             };
             pending_updates.push((rowid, normalized));
         }

--- a/src/cursor/workspace.rs
+++ b/src/cursor/workspace.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs;
 use std::path::Path;
 use url::Url;
@@ -134,9 +135,33 @@ impl WorkspaceJson {
     }
 }
 
+/// Read the primary workspace target URI from a workspace storage directory.
+///
+/// Cursor stores either:
+/// - `folder`: single-folder workspace
+/// - `workspace`: multi-root `.code-workspace` file
+pub fn read_workspace_target_uri(workspace_dir: &Path) -> Result<Option<String>> {
+    let workspace_json = workspace_dir.join("workspace.json");
+    if !workspace_json.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&workspace_json)
+        .with_context(|| format!("Failed to read: {}", workspace_json.display()))?;
+    let ws: Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse: {}", workspace_json.display()))?;
+
+    Ok(ws
+        .get("folder")
+        .and_then(|value| value.as_str())
+        .or_else(|| ws.get("workspace").and_then(|value| value.as_str()))
+        .map(|value| value.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[cfg(not(windows))]
     #[test]
@@ -189,6 +214,41 @@ mod tests {
         assert_eq!(
             normalize_path_for_hash(Path::new("/Users/me/project")),
             "/Users/me/project"
+        );
+    }
+
+    #[test]
+    fn test_read_workspace_target_uri_prefers_folder_then_workspace() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_dir = temp_dir.path().join("ws");
+        fs::create_dir(&workspace_dir).unwrap();
+
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            r#"{"folder":"file:///tmp/project","workspace":"file:///tmp/project.code-workspace"}"#,
+        )
+        .unwrap();
+
+        let target = read_workspace_target_uri(&workspace_dir).unwrap();
+        assert_eq!(target.as_deref(), Some("file:///tmp/project"));
+    }
+
+    #[test]
+    fn test_read_workspace_target_uri_reads_multi_root_workspace() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_dir = temp_dir.path().join("ws");
+        fs::create_dir(&workspace_dir).unwrap();
+
+        fs::write(
+            workspace_dir.join("workspace.json"),
+            r#"{"workspace":"file:///tmp/project.code-workspace"}"#,
+        )
+        .unwrap();
+
+        let target = read_workspace_target_uri(&workspace_dir).unwrap();
+        assert_eq!(
+            target.as_deref(),
+            Some("file:///tmp/project.code-workspace")
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,8 +254,7 @@ fn main() -> Result<()> {
                     anyhow::bail!("Either project_path or --workspace-id must be provided");
                 }
                 (Some(_), Some(_)) => {
-                    // This case is prevented by clap's conflicts_with
-                    unreachable!()
+                    anyhow::bail!("project_path and --workspace-id cannot be used together");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fix the state.vscdb TEXT/BLOB compatibility issue that breaks rename at Step 7 on newer Cursor builds. https://github.com/lucifer1004/cursor-helper/issues/7
- Fix the unsafe rename move path that could partially delete source files before surfacing an error. https://github.com/lucifer1004/cursor-helper/issues/6